### PR TITLE
feat: add account_types

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -1,7 +1,7 @@
 {
     'name': 'ITC Development',
     'version': '1.0',
-    'category': 'Human Resources',
+    'category': 'Accounting',
     'summary': 'Manage Employee Salary Advances with Accounting Integration',
     'author': 'ITC Odoo Team',
     'depends': ['hr', 'hr_payroll', 'account', 'mail'],
@@ -16,6 +16,9 @@
 
         #Purchase Order
         'views/purchase_order.xml',
+
+        #account_account
+        'views/account_account_views.xml',
     ],
     'assets': {
         'web.assets_backend': [

--- a/data/account_type.xml
+++ b/data/account_type.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <data noupdate="1">
+    <record id="account_type_custom_example" model="account.account.type">
+        <field name="name">ITC Test Type</field>
+        <field name="internal_group">equity</field>
+        <field name="include_initial_balance">False</field>
+    </record>
+  </data>
+</odoo>

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,4 @@
 from . import salary_advance
 from . import hr_expense
 from . import purchase_order
+from . import account_account

--- a/models/account_account.py
+++ b/models/account_account.py
@@ -1,0 +1,36 @@
+from odoo import models, fields
+
+class AccountAccount(models.Model):
+    _inherit = 'account.account'
+
+    account_type = fields.Selection(
+        selection_add=[
+            ('expense_manufacturing_oh', 'Manufacturing-OH'),
+            ('asset_non_current_assets_contra', 'Non-current Assets (Contra)'),
+            ('asset_current_assets_contra', 'Current Assets (Contra)'),
+            ('expense_cost_of_sales', 'Cost of Sales'),
+            ('expense_cost_of_services', 'Cost of Services'),
+            ('expense_admin_expense', 'Admin Expenses'),
+            ('asset_current_assets', 'Other Current Assets'),
+            ('expense_non_deductable_expenses', 'Non-Deductible Expenses'),
+            ('income_revenue_contra', 'Revenue (Contra)'),
+            ('income_revenue', 'Revenue'),
+            ('income_sales_contra', 'Sales (Contra)'),
+            ('income_sales', 'Sales'),
+        ],
+        ondelete={
+            'expense_manufacturing_oh': 'cascade',
+            'asset_non_current_assets_contra': 'cascade',
+            'asset_current_assets_contra': 'cascade',
+            'expense_cost_of_sales': 'cascade',
+            'expense_cost_of_services': 'cascade',
+            'expense_admin_expense': 'cascade',
+            'asset_current_assets': 'cascade',
+            'expense_non_deductable_expenses': 'cascade',
+            'income_revenue_contra': 'cascade',
+            'income_revenue': 'cascade',
+            'income_sales_contra': 'cascade',
+            'income_sales': 'cascade',
+        },
+        tracking=True,
+    )

--- a/views/account_account_views.xml
+++ b/views/account_account_views.xml
@@ -1,0 +1,25 @@
+<odoo>
+    <record id="view_account_form_inherit_mfg_oh" model="ir.ui.view">
+        <field name="name">account.account.form.inherit.mfg.oh</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_form"/>
+        <field name="arch" type="xml">
+            <!-- Replace the original field to ensure no attrs/domains are limiting it -->
+            <xpath expr="//field[@name='account_type']" position="replace">
+                <field name="account_type" widget="selection"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_account_list_inherit_mfg_oh" model="ir.ui.view">
+        <field name="name">account.account.list.inherit.mfg.oh</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_list"/>
+        <field name="arch" type="xml">
+            <!-- Replace the existing account_type field -->
+            <xpath expr="//field[@name='account_type']" position="replace">
+                <field name="account_type"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Add custom account type options to the account.account model, update related views to display them, include example data for a new account type, and adjust module metadata accordingly.

New Features:
- Extend account.account model with additional account_type choices and enable tracking

Enhancements:
- Override account.account form and list views to support the extended account_type field
- Include default data record for a custom ITC account type

Build:
- Change module category to Accounting and register new view files in the manifest