### PR TITLE
feat: add fields in sales order

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -24,6 +24,7 @@
         'views/expense_view.xml',
         'views/purchase_order.xml',
         'views/account_account_views.xml',
+        'views/sales_order.xml',
     ],
 
     'assets': {

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,3 +2,4 @@ from . import salary_advance
 from . import hr_expense
 from . import purchase_order
 from . import account_account
+from . import sales_order

--- a/models/sales_order.py
+++ b/models/sales_order.py
@@ -1,0 +1,23 @@
+from odoo import models, fields, api
+from datetime import date
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    x_invoice_type = fields.Selection(
+        [
+            ('service', 'Service'),
+            ('consu', 'Sales'),
+        ],
+        string="Invoice Type",
+        default='service',
+        help="Indicates whether the invoice is Service or Sales."
+    )
+
+    x_partner_tin = fields.Char(
+        string="Customer TIN",
+        related='partner_id.vat',
+        readonly=True,
+        store=True,
+        help="Tax Identification Number of the customer associated with this sales order."
+    )       

--- a/views/sales_order.xml
+++ b/views/sales_order.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Inherit the Sale Order Form View -->
+    <record id="view_order_form_inherit_custom" model="ir.ui.view">
+        <field name="name">sale.order.form.inherit.custom</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Add after customer field -->
+            <xpath expr="//field[@name='partner_id']" position="before">
+                <field name="x_invoice_type" widget="selection"/>
+            </xpath>
+
+            <xpath expr="//field[@name='partner_id']" position="after">
+                <field name="x_partner_tin" readonly="1"/>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Inherit the sales order model to introduce two new fields—Invoice Type and Customer TIN—and update the sales order form view to surface these fields.

New Features:
- Add 'Invoice Type' selection field to sales orders
- Add 'Customer TIN' related field to sales orders
- Extend sales order form view to include the new 'Invoice Type' and 'Customer TIN' fields