### PR TITLE
feat: add service invoice report

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -18,6 +18,7 @@
         'report/sales_order_report.xml',
         'report/purchase_order_report.xml',
         'report/official_receipt_report.xml',
+        'report/service_invoice_report.xml',
 
         #Views
         'views/salary_advance_views.xml',
@@ -25,6 +26,7 @@
         'views/purchase_order.xml',
         'views/account_account_views.xml',
         'views/sales_order.xml',
+        'views/account_move_views.xml',
     ],
 
     'assets': {

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -3,3 +3,4 @@ from . import hr_expense
 from . import purchase_order
 from . import account_account
 from . import sales_order
+from . import account_move

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -1,0 +1,30 @@
+from odoo import models, fields, api
+from datetime import date
+
+class Account(models.Model):
+    _inherit = "account.move"
+
+    x_partner_tin = fields.Char(
+        string="Customer TIN",
+        related='partner_id.vat',
+        readonly=True,
+        store=True,
+        help="Tax Identification Number of the customer associated with this account move."
+    )
+    x_reference_number = fields.Char(
+        string="Reference Number",
+        help="Reference number for this account move."
+    )
+
+    # Help get reference number from sales order
+    @api.onchange('invoice_origin')
+    def _onchange_invoice_origin(self):
+        for record in self:
+            if record.invoice_origin:
+                sale_order = self.env['sale.order'].search([('name', '=', record.invoice_origin)], limit=1)
+                if sale_order:
+                    record.x_reference_number = sale_order.name
+                else:
+                    record.x_reference_number = False
+            else:
+                record.x_reference_number = False   

--- a/report/service_invoice_report.xml
+++ b/report/service_invoice_report.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <!-- ===========================
+       QWeb Template: Sales Invoice
+  ============================ -->
+  <template id="custom_report_service_invoice">
+    <t t-call="web.external_layout">
+      <t t-foreach="docs" t-as="doc">
+        <div class="page" style="font-family: Arial, sans-serif; font-size: 14px; line-height:1.4;">
+          <main>
+
+            <!-- Invoice Header -->
+            <table style="width:100%; margin-bottom:15px; font-size:13px; border-collapse:collapse;">
+              <tr>
+                <td style="width:60%; vertical-align:top; padding:5px; border:1px solid black;">
+                  <strong style="font-size:18px;">SERVICE INVOICE</strong><br/>
+                  <strong>SI NO.:</strong> <t t-esc="doc.name"/><br/>
+                  <strong>BR:</strong> BR-00000-MAIN
+                </td>
+                <td style="width:40%; vertical-align:bottom; padding:5px; text-align:right; border:1px solid black;">
+                  <strong>SI Date:</strong> <t t-esc="doc.invoice_date"/><br/>
+                  <strong>Term:</strong> <t t-esc="doc.invoice_payment_term_id.name or ''"/><br/>
+                </td>
+              </tr>
+            </table>
+
+            <!-- Customer Information -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <tr>
+                <td style="border:1px solid black; padding:5px; width:25%;"><strong>Sold To:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.partner_id.name"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>Address:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.partner_id.street or ''"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>TIN:</strong></td>
+                <td style="border:1px solid black; padding:5px;"><t t-esc="doc.x_partner_tin"/></td>
+                <td style="border:1px solid black; padding:5px;"><strong>Business Style/Trade Name:</strong></td>
+                <td style="border:1px solid black; padding:5px;"><t t-esc="doc.partner_id.name"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>Delivery/Shipped to:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.partner_shipping_id.street or ''"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>Reference:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.ref or ''"/></td>
+              </tr>
+            </table>
+
+            <!-- Invoice Lines Table -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <thead style="background:#f0f0f0;">
+                <tr>
+                  <th style="border:1px solid black; padding:5px; text-align:left;">Description</th>
+                  <th style="border:1px solid black; padding:5px; width:50px;">Qty</th>
+                  <th style="border:1px solid black; padding:5px; width:50px;">Unit</th>
+                  <th style="border:1px solid black; padding:5px; width:80px; text-align:right;">Unit Price</th>
+                  <th style="border:1px solid black; padding:5px; width:80px; text-align:right;">Total</th>
+                  <th style="border:1px solid black; padding:5px; width:80px; text-align:right;">Discount</th>
+                  <th style="border:1px solid black; padding:5px; width:100px; text-align:right;">Net Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr t-foreach="doc.invoice_line_ids" t-as="line">
+                  <td style="border:1px solid black; padding:5px;"><t t-esc="line.name"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:center;"><t t-esc="line.quantity"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:center;"><t t-esc="line.product_uom_id.name"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><t t-esc="line.price_unit"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><t t-esc="line.price_unit * line.quantity"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><t t-esc="line.discount or 0.0"/>%</td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><t t-esc="line.price_subtotal"/></td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="6" style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">TOTAL</td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><t t-esc="doc.amount_untaxed"/></td>
+                </tr>
+              </tfoot>
+            </table>
+
+            <!-- Totals -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <tr>
+                <td rowspan="5" style="width:65%; padding:8px; vertical-align:top; border:1px solid black;">
+                  <p><strong>Amount in words:</strong> <span t-esc="doc.currency_id.amount_to_text(doc.amount_total)"/></p>
+                  <ol style="margin:0; padding-left:15px; font-size:11px;">
+                    <li>Our liability for loss or damage ceases after delivery to the carrier in good order and condition.</li>
+                    <li>This invoice is payable on demand, unless otherwise agreed upon.</li>
+                    <li>The merchandise remains the property of the company until it is fully paid.</li>
+                    <li>Interest will be charged on all overdue accounts.</li>
+                    <li>In case of non-payment, the court of seller will have jurisdiction and the buyer agrees to pay attorney’s fees and court costs resulting therefrom.</li>
+                  </ol>
+                </td>
+                <td style="padding:5px; text-align:right; border:1px solid black;">VATable:</td>
+                <td style="padding:5px; text-align:right; border:1px solid black;"><t t-esc="doc.amount_untaxed"/></td>
+              </tr>
+              <tr>
+                <td style="padding:5px; text-align:right; border:1px solid black;">Zero Rated:</td>
+                <td style="padding:5px; text-align:right; border:1px solid black;">0.00</td>
+              </tr>
+              <tr>
+                <td style="padding:5px; text-align:right; border:1px solid black;">Exempt:</td>
+                <td style="padding:5px; text-align:right; border:1px solid black;">0.00</td>
+              </tr>
+              <tr>
+                <td style="padding:5px; text-align:right; border:1px solid black;">VAT:</td>
+                <td style="padding:5px; text-align:right; border:1px solid black;"><t t-esc="doc.amount_tax"/></td>
+              </tr>
+              <tr>
+                <td style="padding:5px; text-align:right; border:1px solid black; font-weight:bold;">Amount Due:</td>
+                <td style="padding:5px; text-align:right; border:1px solid black; font-weight:bold;"><t t-esc="doc.amount_total"/></td>
+              </tr>
+            </table>
+
+            <!-- Signatories -->
+            <table style="width:100%; font-size:12px; text-align:center; margin-top:20px;">
+              <tr>
+                <td style="border:1px solid black;">Prepared By:</td>
+                <td style="border:1px solid black;">Checked/Approved By:</td>
+                <td style="border:1px solid black;">Received By:</td>
+              </tr>
+              <tr style="height:50px;">
+                <td style="border:1px solid black;"></td>
+                <td style="border:1px solid black;"></td>
+                <td style="border:1px solid black;"></td>
+              </tr>
+              <tr>
+                <td style="font-size:11px; border:1px solid black;">Signature over Printed Name</td>
+                <td style="font-size:11px; border:1px solid black;">Signature over Printed Name</td>
+                <td style="font-size:11px; border:1px solid black;">Signature over Printed Name</td>
+              </tr>
+            </table>
+
+          </main>
+        </div>
+      </t>
+    </t>
+  </template>
+
+  <!-- ===========================
+       REPORT ACTION for account.move
+  ============================ -->
+  <record id="report_service_invoice_account_move" model="ir.actions.report">
+    <field name="name">Service Invoice</field>
+    <field name="model">account.move</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">itc_internal_dev.custom_report_service_invoice</field>
+    <field name="print_report_name">'Service Invoice - %s' % (object.name)</field>
+    <field name="binding_model_id" ref="account.model_account_move"/>
+    <field name="binding_type">report</field>
+  </record>
+</odoo>

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_move_form_inherit_custom" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.custom</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Add a new group aligned with partner_id group -->
+            <xpath expr="//sheet/group" position="inside">
+                <group>
+                    <field name="x_reference_number"/>
+                    <field name="x_partner_tin"/>
+                </group>
+            </xpath>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Add a custom Service Invoice PDF report and extend account.move with customer TIN and reference number fields, including form view integration and auto-population from sales order origin

New Features:
- Introduce a QWeb-based Service Invoice PDF report attached to account.move
- Add x_partner_tin and x_reference_number fields to account.move with onchange logic to derive reference from the originating sales order

Enhancements:
- Expose the new reference and TIN fields in the invoice form view
- Register the service invoice report and view XML files in the module manifest