### PR TITLE
feat: changes

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -19,6 +19,7 @@
         'report/purchase_order_report.xml',
         'report/official_receipt_report.xml',
         'report/service_invoice_report.xml',
+        'report/credit_memo_report.xml',
 
         #Views
         'views/salary_advance_views.xml',

--- a/models/sales_order.py
+++ b/models/sales_order.py
@@ -21,3 +21,8 @@ class SaleOrder(models.Model):
         store=True,
         help="Tax Identification Number of the customer associated with this sales order."
     )       
+
+    x_remarks = fields.Text(
+        string="Remarks",
+        help="Remarks related to this sales order."
+    )

--- a/report/credit_memo_report.xml
+++ b/report/credit_memo_report.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <!-- CREDIT MEMO TEMPLATE -->
+  <template id="custom_report_credit_memo">
+    <t t-foreach="docs" t-as="doc">
+      <t t-set="o" t-value="doc"/> <!-- alias for consistency -->
+      <div class="page" style="font-family: Arial, sans-serif; font-size: 14px; ">
+        <main style="padding: 20px;"> <!-- ✅ required wrapper -->
+
+          <!-- Header -->
+          <table style="width:100%; border-collapse:collapse; margin-bottom:10px;">
+            <tr>
+              <td style="width:70%; vertical-align:top; font-size:12px;">
+                <p style="font-size:14px; font-weight:bold; margin:0;">
+                  <t t-esc="o.company_id.name"/>
+                </p>
+                <p style="margin:2px 0;">
+                  <t t-esc="o.company_id.street or ''"/><br/>
+                  <t t-esc="o.company_id.city or ''"/><br/>
+                  VAT REG TIN: <t t-esc="o.company_id.vat or ''"/><br/>
+                  Telephone No.: <t t-esc="o.company_id.phone or ''"/><br/>
+                  Business Style: <t t-esc="o.company_id.name"/>
+                </p>
+              </td>
+              <td style="width:30%; text-align:right; vertical-align:top;">
+                <h2 style="margin:0; font-size:16px;">CREDIT MEMO</h2>
+                <p style="font-size:13px; margin:0;">
+                  CM-<t t-esc="o.name"/>
+                </p>
+              </td>
+            </tr>
+          </table>
+
+          <!-- Customer Info -->
+          <table style="width:100%; border:1px solid black; border-collapse:collapse; margin-bottom:10px;">
+            <tr>
+              <td style="padding:5px; font-weight:bold; width:15%;">To:</td>
+              <td style="padding:5px; font-weight:bold;">
+                <t t-esc="o.partner_id.name"/>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:5px;">Address:</td>
+              <td style="padding:5px;">
+                <t t-esc="o.partner_id.contact_address or ''"/>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:5px;">VAT REG TIN:</td>
+              <td style="padding:5px;"><t t-esc="o.partner_id.vat or ''"/></td>
+            </tr>
+          </table>
+
+          <!-- Date -->
+          <p style="text-align:right; font-size:12px; margin:0 0 10px 0;">
+            DATE: <t t-esc="o.invoice_date or o.create_date"/>
+          </p>
+
+          <!-- Description vs Amount -->
+          <table style="width:100%; border:1px solid black; border-collapse:collapse; margin-bottom:15px;">
+            <thead>
+              <tr>
+                <th style="width:70%; padding:5px; border:1px solid black; text-align:center;">DESCRIPTION</th>
+                <th style="width:30%; padding:5px; border:1px solid black; text-align:center;">AMOUNT</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style="padding:5px; border:1px solid black;">Remarks: <t t-esc="o.narration or ''"/></td>
+                <td style="padding:5px; border:1px solid black; text-align:right;">
+                  VATABLE: <t t-esc="o.amount_untaxed"/>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:5px; border:1px solid black;">Reference: <t t-esc="o.ref or ''"/></td>
+                <td style="padding:5px; border:1px solid black; text-align:right;">ZERO RATED: 0.00</td>
+              </tr>
+              <tr>
+                <td style="padding:5px; border:1px solid black;">Reason: <t t-esc="o.invoice_origin or ''"/></td>
+                <td style="padding:5px; border:1px solid black; text-align:right;">VAT-EXEMPT: 0.00</td>
+              </tr>
+              <tr>
+                <td style="padding:5px; border:1px solid black;"></td>
+                <td style="padding:5px; border:1px solid black; text-align:right;">
+                  VAT(12%): <t t-esc="o.amount_tax"/>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td style="padding:5px; border:1px solid black; font-weight:bold;"></td>
+                <td style="padding:5px; border:1px solid black; text-align:right; font-weight:bold;">
+                  TOTAL: <t t-esc="o.amount_total"/>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+
+          <!-- Signatories -->
+          <table style="width:100%; text-align:center; border-collapse:collapse; font-size:12px; margin-top:20px;">
+            <tr>
+              <td style="border:1px solid black; padding:10px;">PREPARED BY:</td>
+              <td style="border:1px solid black; padding:10px;">CERTIFIED CORRECT BY:</td>
+              <td style="border:1px solid black; padding:10px;">APPROVED BY:</td>
+            </tr>
+            <tr style="height:50px;">
+              <td style="border:1px solid black;"></td>
+              <td style="border:1px solid black;"></td>
+              <td style="border:1px solid black;"></td>
+            </tr>
+          </table>
+
+          <!-- Footer -->
+          <p style="font-size:10px; margin-top:20px; text-align:left;">
+            Printed By: Custom Credit Memo Module<br/>
+            Acknowledgment Certificate No: ___________<br/>
+            Acknowledgment Certificate Date Issued: ___________<br/>
+            Permitted Series Range: CM-000000000001 - CM-999999999999
+          </p>
+
+        </main>
+      </div>
+    </t>
+  </template>
+
+  <!-- REPORT ACTION -->
+  <record id="action_report_credit_memo_custom" model="ir.actions.report">
+    <field name="name">Credit Memo</field>
+    <field name="model">account.move</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">itc_internal_dev.custom_report_credit_memo</field>
+    <field name="print_report_name">'Credit Memo - %s' % (object.name)</field>
+    <field name="binding_model_id" ref="account.model_account_move"/>
+    <field name="binding_type">report</field>
+  </record>
+</odoo>

--- a/views/sales_order.xml
+++ b/views/sales_order.xml
@@ -16,6 +16,10 @@
                 <field name="x_partner_tin" readonly="1"/>
             </xpath>
 
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="x_remarks"/>
+            </xpath>
+
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a free-text remarks field on sales orders and implement a new QWeb PDF credit memo report for account moves

New Features:
- Add x_remarks text field to sale.order model and display it in the sales order form view
- Create a custom QWeb PDF credit memo report template with header, customer details, line items, and signature blocks
- Register the new credit memo report in the module manifest and bind it to the account.move model

Enhancements:
- Update __manifest__.py to include the credit memo report file