### PR TITLE
feat: add selection and button for services and sales invoice

### DIFF
--- a/models/account_move.py
+++ b/models/account_move.py
@@ -1,8 +1,17 @@
 from odoo import models, fields, api
-from datetime import date
 
 class Account(models.Model):
     _inherit = "account.move"
+
+    x_invoice_type = fields.Selection(
+        [
+            ('service', 'Service'),
+            ('consu', 'Sales'),
+        ],
+        string="Invoice Type",
+        default='service',
+        help="Indicates whether the invoice is Service or Sales."
+    )
 
     x_partner_tin = fields.Char(
         string="Customer TIN",
@@ -11,20 +20,21 @@ class Account(models.Model):
         store=True,
         help="Tax Identification Number of the customer associated with this account move."
     )
+
     x_reference_number = fields.Char(
         string="Reference Number",
         help="Reference number for this account move."
     )
 
-    # Help get reference number from sales order
-    @api.onchange('invoice_origin')
-    def _onchange_invoice_origin(self):
-        for record in self:
-            if record.invoice_origin:
-                sale_order = self.env['sale.order'].search([('name', '=', record.invoice_origin)], limit=1)
-                if sale_order:
-                    record.x_reference_number = sale_order.name
-                else:
-                    record.x_reference_number = False
-            else:
-                record.x_reference_number = False   
+    @api.model
+    def create(self, vals):
+        move = super().create(vals)
+        if move.invoice_origin:
+            sale_order = self.env['sale.order'].search(
+                [('name', '=', move.invoice_origin)], limit=1
+            )
+            if sale_order:
+                move.x_reference_number = sale_order.name
+                move.x_invoice_type = sale_order.x_invoice_type or 'service'
+        return move
+

--- a/report/sales_order_report.xml
+++ b/report/sales_order_report.xml
@@ -54,7 +54,8 @@
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>Reference:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.client_order_ref or ''"/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.x_reference_number or ''"/></td>
+
               </tr>
             </table>
 

--- a/report/service_invoice_report.xml
+++ b/report/service_invoice_report.xml
@@ -46,7 +46,7 @@
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>Reference:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.ref or ''"/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><t t-esc="doc.x_reference_number or ''"/></td>
               </tr>
             </table>
 

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -7,8 +7,21 @@
         <field name="arch" type="xml">
 
             <!-- Add a new group aligned with partner_id group -->
+            
+            <header position="inside">
+                    <button name="%(report_service_invoice_account_move)d"
+                            string="Print Service Invoice"
+                            type="action"
+                            class="btn-primary"/>
+                    <button name="%(report_sales_invoice_account_move)d"
+                            string="Print Sales Invoice"
+                            type="action"
+                            class="btn-primary"/>
+            </header>
+
             <xpath expr="//sheet/group" position="inside">
                 <group>
+                    <field name="x_invoice_type" widget="selection"/>
                     <field name="x_reference_number"/>
                     <field name="x_partner_tin"/>
                 </group>


### PR DESCRIPTION
## Summary by Sourcery

Add invoice type selection, auto-populated reference from sale orders, and printing buttons, and update reports to reflect the new reference field

New Features:
- Add x_invoice_type selection field to invoices for distinguishing Service or Sales invoices
- Add Print Service Invoice and Print Sales Invoice buttons in the invoice header

Enhancements:
- Auto-populate x_reference_number and x_invoice_type from the related sale order upon invoice creation
- Update service and sales invoice reports to display the new x_reference_number field instead of client_order_ref or ref