### PR TITLE
feat: add dollar conversion

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,6 +28,7 @@
         'views/account_account_views.xml',
         'views/sales_order.xml',
         'views/account_move_views.xml',
+        #'views/sales_order_line.xml',
     ],
 
     'assets': {

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,3 +4,4 @@ from . import purchase_order
 from . import account_account
 from . import sales_order
 from . import account_move
+from . import sales_order_line

--- a/models/sales_order.py
+++ b/models/sales_order.py
@@ -1,8 +1,34 @@
 from odoo import models, fields, api
-from datetime import date
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    currency_id = fields.Many2one(
+        'res.currency',
+        string='Currency',
+        required=True,
+        default=lambda self: self.env.company.currency_id,
+        help="The currency used for this sales order.",
+        readonly=False
+    )
+
+    company_id = fields.Many2one(
+        'res.company',
+        string='Company',
+        required=True,
+        default=lambda self: self.env.company,
+        help="The company associated with this sales order.",
+        readonly=True
+    )
+
+    x_conversion_rate = fields.Float(
+        string="Conversion Rate",
+        digits=(12, 6),
+        compute="_compute_conversion_rate",
+        store=True,
+        readonly=False,
+        help="The conversion rate from the selected currency to the company's base currency (PHP)."
+    )
 
     x_invoice_type = fields.Selection(
         [
@@ -20,9 +46,42 @@ class SaleOrder(models.Model):
         readonly=True,
         store=True,
         help="Tax Identification Number of the customer associated with this sales order."
-    )       
+    )
 
     x_remarks = fields.Text(
         string="Remarks",
         help="Remarks related to this sales order."
     )
+
+    
+    planned_rate = fields.Float(
+        string="Planned Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Budgeted or expected conversion rate.",
+    )
+
+    actual_rate = fields.Float(
+        string="Actual Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Actual conversion rate at transaction/payment time.",
+    )
+
+
+    @api.depends('currency_id', 'date_order', 'company_id')
+    def _compute_conversion_rate(self):
+        """Always compute conversion rate based on currency and date."""
+        for order in self:
+            if order.currency_id and order.company_id.currency_id:
+                company_currency = order.company_id.currency_id
+                order_currency = order.currency_id
+                order_date = order.date_order or fields.Date.today()
+
+                # Fetch rate for the selected currency
+                rate = order_currency._get_rates(
+                    company=order.company_id,
+                    date=order_date
+                ).get(order_currency.id)
+
+                order.x_conversion_rate = rate or 1.0
+            else:
+                order.x_conversion_rate = 1.0

--- a/models/sales_order_line.py
+++ b/models/sales_order_line.py
@@ -1,0 +1,55 @@
+from odoo import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+
+    planned_rate = fields.Float(
+        string="Planned Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Budgeted or expected conversion rate.",
+    )
+
+    actual_rate = fields.Float(
+        string="Actual Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Actual conversion rate at transaction/payment time.",
+    )
+
+    x_unit_price_usd = fields.Float(
+        string="Unit Price (USD)",
+        digits="Product Price",
+        compute="_compute_unit_price_usd",
+        inverse="_inverse_unit_price_usd",
+        store=True,
+        help="Unit price in USD for this sales order line.",
+    )
+
+    x_gain_loss = fields.Float(
+        string="FX Gain/Loss (USD)",
+        compute="_compute_gain_loss",
+        store=True,
+        help="Difference between expected USD and actual USD conversion.",
+    )
+
+    @api.depends("price_unit", "order_id.x_conversion_rate")
+    def _compute_unit_price_usd(self):
+        for line in self:
+            rate = line.order_id.x_conversion_rate or 1.0
+            line.x_unit_price_usd = line.price_unit / rate
+
+    def _inverse_unit_price_usd(self):
+        for line in self:
+            rate = line.order_id.x_conversion_rate or 1.0
+            line.price_unit = line.x_unit_price_usd * rate
+
+    @api.depends("planned_rate", "actual_rate", "price_unit")
+    def _compute_gain_loss(self):
+        for line in self:
+            if line.planned_rate and line.actual_rate:
+                expected = line.price_unit / line.planned_rate
+                actual = line.price_unit / line.actual_rate
+                line.x_gain_loss = actual - expected
+            else:
+                line.x_gain_loss = 0.0

--- a/views/sales_order.xml
+++ b/views/sales_order.xml
@@ -7,6 +7,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
 
+
             <!-- Add after customer field -->
             <xpath expr="//field[@name='partner_id']" position="before">
                 <field name="x_invoice_type" widget="selection"/>
@@ -16,10 +17,30 @@
                 <field name="x_partner_tin" readonly="1"/>
             </xpath>
 
+            <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="x_conversion_rate"/>
+            </xpath>
+
             <xpath expr="//field[@name='payment_term_id']" position="after">
                 <field name="x_remarks"/>
             </xpath>
+           
+            <!-- Add USD field in Order Line tree -->
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="after">
+                <field name="x_unit_price_usd"/>
+                <field name="planned_rate" />
+                <field name="actual_rate" />
+                <field name="x_gain_loss"/>
+            </xpath>
 
+            <!-- Add USD field in Order Line form -->
+            <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+                <field name="x_unit_price_usd"/>
+                <field name="planned_rate" />
+                <field name="actual_rate" />
+                <field name="x_gain_loss"/>
+            </xpath>
+            
         </field>
     </record>
 </odoo>

--- a/views/sales_order_line.xml
+++ b/views/sales_order_line.xml
@@ -1,0 +1,22 @@
+<odoo>
+  <record id="view_order_form_inherit_custom" model="ir.ui.view">
+    <field name="name">sale.order.form.inherit.custom</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form"/>
+    <field name="arch" type="xml">
+
+      <!-- Add after Unit Price -->
+      <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+        <field name="x_unit_price_usd"/>
+      </xpath>
+
+      <!-- Or Add before Unit Price -->
+      <!--
+      <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="before">
+        <field name="x_custom_field"/>
+      </xpath>
+      -->
+
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Add multi-currency handling to sale orders by computing conversion rates, USD pricing, and FX gain/loss, and update corresponding views to display the new fields.

New Features:
- Introduce multi-currency support on sale orders with explicit currency, company, and computed conversion rate based on the order date
- Add planned and actual conversion rate fields on sale orders and their lines for budgeting versus actual tracking
- Compute and store USD unit price with inverse calculation and FX gain/loss on sale order lines
- Update sale order and order line views to surface conversion rate, USD pricing, planned/actual rates, and FX gain/loss fields