### PR TITLE
Dev

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -20,7 +20,7 @@
         'report/official_receipt_report.xml',
         'report/service_invoice_report.xml',
         'report/credit_memo_report.xml',
-
+        'report/report_statement_of_account_template.xml',
         #Views
         'views/salary_advance_views.xml',
         'views/expense_view.xml',

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -28,6 +28,7 @@
         'views/account_account_views.xml',
         'views/sales_order.xml',
         'views/account_move_views.xml',
+        #'views/sales_order_line.xml',
     ],
 
     'assets': {

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,3 +4,4 @@ from . import purchase_order
 from . import account_account
 from . import sales_order
 from . import account_move
+from . import sales_order_line

--- a/models/sales_order.py
+++ b/models/sales_order.py
@@ -1,8 +1,34 @@
 from odoo import models, fields, api
-from datetime import date
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    currency_id = fields.Many2one(
+        'res.currency',
+        string='Currency',
+        required=True,
+        default=lambda self: self.env.company.currency_id,
+        help="The currency used for this sales order.",
+        readonly=False
+    )
+
+    company_id = fields.Many2one(
+        'res.company',
+        string='Company',
+        required=True,
+        default=lambda self: self.env.company,
+        help="The company associated with this sales order.",
+        readonly=True
+    )
+
+    x_conversion_rate = fields.Float(
+        string="Conversion Rate",
+        digits=(12, 6),
+        compute="_compute_conversion_rate",
+        store=True,
+        readonly=False,
+        help="The conversion rate from the selected currency to the company's base currency (PHP)."
+    )
 
     x_invoice_type = fields.Selection(
         [
@@ -20,9 +46,42 @@ class SaleOrder(models.Model):
         readonly=True,
         store=True,
         help="Tax Identification Number of the customer associated with this sales order."
-    )       
+    )
 
     x_remarks = fields.Text(
         string="Remarks",
         help="Remarks related to this sales order."
     )
+
+    
+    planned_rate = fields.Float(
+        string="Planned Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Budgeted or expected conversion rate.",
+    )
+
+    actual_rate = fields.Float(
+        string="Actual Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Actual conversion rate at transaction/payment time.",
+    )
+
+
+    @api.depends('currency_id', 'date_order', 'company_id')
+    def _compute_conversion_rate(self):
+        """Always compute conversion rate based on currency and date."""
+        for order in self:
+            if order.currency_id and order.company_id.currency_id:
+                company_currency = order.company_id.currency_id
+                order_currency = order.currency_id
+                order_date = order.date_order or fields.Date.today()
+
+                # Fetch rate for the selected currency
+                rate = order_currency._get_rates(
+                    company=order.company_id,
+                    date=order_date
+                ).get(order_currency.id)
+
+                order.x_conversion_rate = rate or 1.0
+            else:
+                order.x_conversion_rate = 1.0

--- a/models/sales_order_line.py
+++ b/models/sales_order_line.py
@@ -1,0 +1,55 @@
+from odoo import models, fields, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+
+    planned_rate = fields.Float(
+        string="Planned Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Budgeted or expected conversion rate.",
+    )
+
+    actual_rate = fields.Float(
+        string="Actual Rate (PHP per USD)",
+        digits=(12, 6),
+        help="Actual conversion rate at transaction/payment time.",
+    )
+
+    x_unit_price_usd = fields.Float(
+        string="Unit Price (USD)",
+        digits="Product Price",
+        compute="_compute_unit_price_usd",
+        inverse="_inverse_unit_price_usd",
+        store=True,
+        help="Unit price in USD for this sales order line.",
+    )
+
+    x_gain_loss = fields.Float(
+        string="FX Gain/Loss (USD)",
+        compute="_compute_gain_loss",
+        store=True,
+        help="Difference between expected USD and actual USD conversion.",
+    )
+
+    @api.depends("price_unit", "order_id.x_conversion_rate")
+    def _compute_unit_price_usd(self):
+        for line in self:
+            rate = line.order_id.x_conversion_rate or 1.0
+            line.x_unit_price_usd = line.price_unit / rate
+
+    def _inverse_unit_price_usd(self):
+        for line in self:
+            rate = line.order_id.x_conversion_rate or 1.0
+            line.price_unit = line.x_unit_price_usd * rate
+
+    @api.depends("planned_rate", "actual_rate", "price_unit")
+    def _compute_gain_loss(self):
+        for line in self:
+            if line.planned_rate and line.actual_rate:
+                expected = line.price_unit / line.planned_rate
+                actual = line.price_unit / line.actual_rate
+                line.x_gain_loss = actual - expected
+            else:
+                line.x_gain_loss = 0.0

--- a/report/official_receipt_report.xml
+++ b/report/official_receipt_report.xml
@@ -28,8 +28,7 @@
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>Address:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><span/>, <span t-field="doc.partner_id.street2"/>, <span t-field="doc.partner_id.city
-                "/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><span/>, <span t-field="doc.partner_id.street2"/></td>
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>TIN:</strong></td>

--- a/report/report_statement_of_account_template.xml
+++ b/report/report_statement_of_account_template.xml
@@ -11,11 +11,11 @@
               <tr>
                 <td style="width:60%; vertical-align:top; padding:5px; border:1px solid black;">
                   <strong style="font-size:18px;">STATEMENT OF ACCOUNT</strong><br/>
-                  <strong>SOA NO.:</strong> <span t-esc="doc.soa_no or doc.name"/><br/>
+                  <strong>SOA NO.:</strong> <span t-esc="doc.name"/><br/>
                   <strong>BR:</strong> BR-00000-MAIN
                 </td>
                 <td style="width:40%; vertical-align:bottom; padding:5px; text-align:right; border:1px solid black;">
-                  <strong>SOA Date:</strong> <span t-esc="doc.date or doc.date_start" t-options='{"format": "MMMM dd, yyyy"}'/><br/>
+                  <strong>SOA Date:</strong> <span t-esc="doc.date"/><br/>
                   <strong>Term:</strong> 15 Days
                 </td>
               </tr>
@@ -38,7 +38,7 @@
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>Particulars:</strong></td>
                 <td style="border:1px solid black; padding:5px;" colspan="3">
-                  Billing from <span t-esc="doc.date_start"/> to <span t-esc="doc.date_end"/>
+                  Billing Date <span t-esc="doc.date"/> 
                 </td>
               </tr>
             </table>

--- a/report/report_statement_of_account_template.xml
+++ b/report/report_statement_of_account_template.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <!-- QWeb Template: Statement of Account -->
+  <template id="report_statement_of_account_template">
+    <t t-call="web.external_layout">
+      <t t-foreach="docs" t-as="doc">
+        <div class="page" style="font-family: Arial, sans-serif; font-size: 14px; line-height:1.4;">
+          <main>
+            <!-- SOA Header -->
+            <table style="width:100%; margin-bottom:15px; font-size:13px; border-collapse:collapse;">
+              <tr>
+                <td style="width:60%; vertical-align:top; padding:5px; border:1px solid black;">
+                  <strong style="font-size:18px;">STATEMENT OF ACCOUNT</strong><br/>
+                  <strong>SOA NO.:</strong> <span t-esc="doc.soa_no or doc.name"/><br/>
+                  <strong>BR:</strong> BR-00000-MAIN
+                </td>
+                <td style="width:40%; vertical-align:bottom; padding:5px; text-align:right; border:1px solid black;">
+                  <strong>SOA Date:</strong> <span t-esc="doc.date or doc.date_start" t-options='{"format": "MMMM dd, yyyy"}'/><br/>
+                  <strong>Term:</strong> 15 Days
+                </td>
+              </tr>
+            </table>
+
+            <!-- Customer Information -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <tr>
+                <td style="border:1px solid black; padding:5px; width:25%;"><strong>Customer:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><span t-field="doc.partner_id.name"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>Address:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><span t-field="doc.partner_id.contact_address"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>TIN:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3"><span t-field="doc.partner_id.vat"/></td>
+              </tr>
+              <tr>
+                <td style="border:1px solid black; padding:5px;"><strong>Particulars:</strong></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3">
+                  Billing from <span t-esc="doc.date_start"/> to <span t-esc="doc.date_end"/>
+                </td>
+              </tr>
+            </table>
+
+            <!-- Reference Details -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <thead style="background:#f0f0f0;">
+                <tr>
+                  <th style="border:1px solid black; padding:5px;">Reference Date</th>
+                  <th style="border:1px solid black; padding:5px;">Reference No.</th>
+                  <th style="border:1px solid black; padding:5px;">Due Date</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right;">Ref Amount</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right;">Output VAT</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right;">Tax Base</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right;">CWT</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right;">Net Amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                <t t-foreach="doc.line_ids" t-as="line">
+                  <tr>
+                    <td style="border:1px solid black; padding:5px;"><span t-field="line.reference_date"/></td>
+                    <td style="border:1px solid black; padding:5px;"><span t-field="line.reference_no"/></td>
+                    <td style="border:1px solid black; padding:5px;"><span t-field="line.due_date"/></td>
+                    <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="line.ref_amount"/></td>
+                    <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="line.output_vat"/></td>
+                    <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="line.tax_base"/></td>
+                    <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="line.cwt"/></td>
+                    <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="line.net_amount"/></td>
+                  </tr>
+                </t>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="3" style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">Total</td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;" colspan="5"><span t-field="doc.total_amount"/></td>
+                </tr>
+              </tfoot>
+            </table>
+
+            <!-- Amount in Words -->
+            <p style="margin-bottom:15px;"><strong>Amount in Words:</strong> ***<span t-esc="doc.amount_in_words"/>***</p>
+
+            <!-- Aging Schedule -->
+            <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
+              <thead style="background:#f0f0f0;">
+                <tr>
+                  <th style="border:1px solid black; padding:5px;">Current</th>
+                  <th style="border:1px solid black; padding:5px;">1-30 Days</th>
+                  <th style="border:1px solid black; padding:5px;">31-60 Days</th>
+                  <th style="border:1px solid black; padding:5px;">61-90 Days</th>
+                  <th style="border:1px solid black; padding:5px;">91-120 Days</th>
+                  <th style="border:1px solid black; padding:5px;">Over 120 Days</th>
+                  <th style="border:1px solid black; padding:5px;">Total Amount Due</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.current_amount"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.days_1_30"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.days_31_60"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.days_61_90"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.days_91_120"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.days_over_120"/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.total_amount"/></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <!-- Signatories -->
+            <table style="width:100%; font-size:12px; text-align:center; margin-top:20px; border-collapse:collapse;">
+              <tr>
+                <td style="border:1px solid black; width:33%;">Prepared By:<br/><br/>Signature Over Printed Name</td>
+                <td style="border:1px solid black; width:33%;">Checked/Approved By:<br/><br/>Signature Over Printed Name</td>
+                <td style="border:1px solid black; width:33%;">Received By:<br/><br/>Signature Over Printed Name</td>
+              </tr>
+            </table>
+
+            <!-- Footer -->
+            <p style="font-size:10px; margin-top:20px; text-align:center;">
+              Page 1 of 1<br/>
+              THIS DOCUMENT IS NOT VALID FOR CLAIM OF INPUT TAX
+            </p>
+          </main>
+        </div>
+      </t>
+    </t>
+  </template>
+
+  <!-- REPORT ACTION for Statement of Account -->
+  <record id="action_report_statement_of_account" model="ir.actions.report">
+    <field name="name">Statement of Account</field>
+    <field name="model">account.payment</field>
+    <field name="report_type">qweb-pdf</field>
+    <field name="report_name">itc_internal_dev.report_statement_of_account_template</field>
+    <field name="print_report_name">'SOA - %s' % (object.partner_id.name)</field>
+    <field name="binding_model_id" ref="account.model_account_payment"/>
+    <field name="binding_type">report</field>
+  </record>
+</odoo>

--- a/views/sales_order.xml
+++ b/views/sales_order.xml
@@ -7,6 +7,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
 
+
             <!-- Add after customer field -->
             <xpath expr="//field[@name='partner_id']" position="before">
                 <field name="x_invoice_type" widget="selection"/>
@@ -16,10 +17,30 @@
                 <field name="x_partner_tin" readonly="1"/>
             </xpath>
 
+            <xpath expr="//field[@name='currency_id']" position="after">
+                <field name="x_conversion_rate"/>
+            </xpath>
+
             <xpath expr="//field[@name='payment_term_id']" position="after">
                 <field name="x_remarks"/>
             </xpath>
+           
+            <!-- Add USD field in Order Line tree -->
+            <xpath expr="//field[@name='order_line']/list/field[@name='price_unit']" position="after">
+                <field name="x_unit_price_usd"/>
+                <field name="planned_rate" />
+                <field name="actual_rate" />
+                <field name="x_gain_loss"/>
+            </xpath>
 
+            <!-- Add USD field in Order Line form -->
+            <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+                <field name="x_unit_price_usd"/>
+                <field name="planned_rate" />
+                <field name="actual_rate" />
+                <field name="x_gain_loss"/>
+            </xpath>
+            
         </field>
     </record>
 </odoo>

--- a/views/sales_order_line.xml
+++ b/views/sales_order_line.xml
@@ -1,0 +1,22 @@
+<odoo>
+  <record id="view_order_form_inherit_custom" model="ir.ui.view">
+    <field name="name">sale.order.form.inherit.custom</field>
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form"/>
+    <field name="arch" type="xml">
+
+      <!-- Add after Unit Price -->
+      <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="after">
+        <field name="x_unit_price_usd"/>
+      </xpath>
+
+      <!-- Or Add before Unit Price -->
+      <!--
+      <xpath expr="//field[@name='order_line']/form//field[@name='price_unit']" position="before">
+        <field name="x_custom_field"/>
+      </xpath>
+      -->
+
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Enable multi-currency support on sales orders by adding conversion rate and USD pricing fields, compute FX gain/loss on order lines, enhance sale order views, fix an address issue in an existing report, and introduce a Statement of Account report.

New Features:
- Add currency and company fields to sale orders with computed conversion rate
- Introduce planned and actual exchange rate fields on sale orders and order lines
- Compute unit price in USD and FX gain/loss on sale order lines
- Add a new Statement of Account QWeb report

Bug Fixes:
- Correct address rendering in the official receipt report

Enhancements:
- Extend sale order views to display invoice type, remarks, conversion rate, USD pricing, planned/actual rates, and gain/loss
- Update manifest to include the new report template