### PR TITLE
feat: added module for 1604eq

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -26,6 +26,7 @@
         'report/report_statement_of_account_template.xml',
         'report/acknowledgement_report.xml',
         'report/bir_0619e.xml',
+        'report/bir_1604e_report.xml',
         #Views
         'views/salary_advance_views.xml',
         'views/expense_view.xml',
@@ -39,6 +40,7 @@
         'views/bir_1702q_views.xml',
         'views/bir_2550q_views.xml',
         'views/bir_1601eq_views.xml',
+        'views/bir_1604e_views.xml',
         'views/bir_form_view.xml',
     ],
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -7,5 +7,5 @@ from . import account_move
 from . import sales_order_line
 from . import sql_report
 from . import account_statement
-from . import bir_model, bir_1601eq, bir_2550q, bir_0619e, bir_1702q
+from . import bir_model, bir_1601eq, bir_2550q, bir_0619e, bir_1702q, bir_1604e
 #from . import report_xlsx_global 

--- a/models/bir_1604e.py
+++ b/models/bir_1604e.py
@@ -1,0 +1,705 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api
+from odoo.exceptions import ValidationError
+import xlsxwriter
+import base64
+from io import BytesIO
+from datetime import datetime, date
+from dateutil.relativedelta import relativedelta
+
+
+class BIR1604E(models.Model):
+    _name = 'bir.1604e'
+    _description = 'BIR Form 1604-E - Annual Information Return'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+    _order = 'year desc'
+
+    name = fields.Char(string='Reference', required=True, copy=False, readonly=True, default='New')
+    
+    # Period Information
+    year = fields.Integer(string='Year', required=True, default=lambda self: datetime.now().year, tracking=True)
+    date_from = fields.Date(string='Period From', compute='_compute_period_dates', store=True)
+    date_to = fields.Date(string='Period To', compute='_compute_period_dates', store=True)
+    
+    # Company Information
+    company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
+    tin = fields.Char(string='TIN', related='company_id.vat', readonly=True)
+    withholding_agent_name = fields.Char(string='Withholding Agent Name', related='company_id.name', readonly=True)
+    registered_address = fields.Text(string='Registered Address', compute='_compute_company_address', store=True)
+    rdo_code = fields.Char(string='RDO Code')
+    line_of_business = fields.Char(string='Line of Business/Occupation')
+    
+    # Return Information
+    amended_return = fields.Boolean(string='Amended Return?', default=False)
+    num_sheets_attached = fields.Integer(string='No. of Sheets Attached', compute='_compute_sheets_attached', store=True)
+    
+    # Category
+    category_private = fields.Boolean(string='Private', default=True)
+    category_government = fields.Boolean(string='Government', default=False)
+    
+    # Schedule 1: Form 1601-E Remittances
+    schedule1_line_ids = fields.One2many('bir.1604e.schedule1', 'form_id', string='Schedule 1 - Form 1601-E Remittances')
+    total_1601e_taxes = fields.Float(string='Total 1601-E Taxes', compute='_compute_schedule_totals', store=True)
+    total_1601e_penalties = fields.Float(string='Total 1601-E Penalties', compute='_compute_schedule_totals', store=True)
+    total_1601e_remitted = fields.Float(string='Total 1601-E Remitted', compute='_compute_schedule_totals', store=True)
+    
+    # Schedule 2: Form 1606 Remittances
+    schedule2_line_ids = fields.One2many('bir.1604e.schedule2', 'form_id', string='Schedule 2 - Form 1606 Remittances')
+    total_1606_taxes = fields.Float(string='Total 1606 Taxes', compute='_compute_schedule_totals', store=True)
+    total_1606_penalties = fields.Float(string='Total 1606 Penalties', compute='_compute_schedule_totals', store=True)
+    total_1606_remitted = fields.Float(string='Total 1606 Remitted', compute='_compute_schedule_totals', store=True)
+    
+    # Schedule 3: Exempt from Withholding
+    schedule3_line_ids = fields.One2many('bir.1604e.schedule3', 'form_id', string='Schedule 3 - Exempt from Withholding')
+    total_schedule3_amount = fields.Float(string='Total Schedule 3', compute='_compute_schedule_totals', store=True)
+    
+    # Schedule 4: Expanded Withholding Tax
+    schedule4_line_ids = fields.One2many('bir.1604e.schedule4', 'form_id', string='Schedule 4 - Expanded Withholding Tax')
+    total_schedule4_income = fields.Float(string='Total Schedule 4 Income', compute='_compute_schedule_totals', store=True)
+    
+    # Status
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('computed', 'Computed'),
+        ('submitted', 'Submitted')
+    ], string='Status', default='draft', tracking=True)
+    
+    # Signatory
+    signatory_name = fields.Char(string='Signatory Name')
+    signatory_title = fields.Char(string='Signatory Title')
+    
+    # Export
+    excel_file = fields.Binary(string='Excel File', readonly=True)
+    excel_filename = fields.Char(string='Excel Filename', readonly=True)
+    
+    report_date = fields.Date(string='Report Date', default=fields.Date.today)
+    
+    @api.depends('year')
+    def _compute_period_dates(self):
+        for record in self:
+            if record.year:
+                record.date_from = date(record.year, 1, 1)
+                record.date_to = date(record.year, 12, 31)
+    
+    @api.depends('company_id')
+    def _compute_company_address(self):
+        for record in self:
+            if record.company_id:
+                address_parts = []
+                if record.company_id.street:
+                    address_parts.append(record.company_id.street)
+                if record.company_id.street2:
+                    address_parts.append(record.company_id.street2)
+                if record.company_id.city:
+                    address_parts.append(record.company_id.city)
+                if record.company_id.state_id:
+                    address_parts.append(record.company_id.state_id.name)
+                if record.company_id.zip:
+                    address_parts.append(record.company_id.zip)
+                if record.company_id.country_id:
+                    address_parts.append(record.company_id.country_id.name)
+                
+                record.registered_address = ', '.join(address_parts)
+    
+    @api.depends('schedule3_line_ids', 'schedule4_line_ids')
+    def _compute_sheets_attached(self):
+        for record in self:
+            sheets = 0
+            if record.schedule3_line_ids:
+                sheets += (len(record.schedule3_line_ids) // 20) + 1
+            if record.schedule4_line_ids:
+                sheets += (len(record.schedule4_line_ids) // 30) + 1
+            record.num_sheets_attached = sheets
+    
+    @api.depends('schedule1_line_ids.taxes_withheld', 'schedule1_line_ids.penalties', 'schedule1_line_ids.total_remitted',
+                 'schedule2_line_ids.taxes_withheld', 'schedule2_line_ids.penalties', 'schedule2_line_ids.total_remitted',
+                 'schedule3_line_ids.income_payment', 'schedule4_line_ids.income_payment')
+    def _compute_schedule_totals(self):
+        for record in self:
+            record.total_1601e_taxes = sum(record.schedule1_line_ids.mapped('taxes_withheld'))
+            record.total_1601e_penalties = sum(record.schedule1_line_ids.mapped('penalties'))
+            record.total_1601e_remitted = sum(record.schedule1_line_ids.mapped('total_remitted'))
+            
+            record.total_1606_taxes = sum(record.schedule2_line_ids.mapped('taxes_withheld'))
+            record.total_1606_penalties = sum(record.schedule2_line_ids.mapped('penalties'))
+            record.total_1606_remitted = sum(record.schedule2_line_ids.mapped('total_remitted'))
+            
+            record.total_schedule3_amount = sum(record.schedule3_line_ids.mapped('income_payment'))
+            record.total_schedule4_income = sum(record.schedule4_line_ids.mapped('income_payment'))
+    
+    @api.model
+    def create(self, vals):
+        if vals.get('name', 'New') == 'New':
+            vals['name'] = self.env['ir.sequence'].next_by_code('bir.1604e') or 'New'
+        return super(BIR1604E, self).create(vals)
+    
+    def action_generate_data(self):
+        """Generate annual data from various sources"""
+        self.ensure_one()
+        
+        # Clear existing lines
+        self.schedule1_line_ids.unlink()
+        self.schedule2_line_ids.unlink()
+        self.schedule3_line_ids.unlink()
+        self.schedule4_line_ids.unlink()
+        
+        # Generate Schedule 1: From quarterly 1601-EQ forms (if using that module)
+        self._generate_schedule1()
+        
+        # Generate Schedule 2: From Form 1606 data (if exists)
+        self._generate_schedule2()
+        
+        # Generate Schedule 3: Exempt from withholding (from vendor bills)
+        self._generate_schedule3()
+        
+        # Generate Schedule 4: Expanded withholding tax (from vendor bills with EWT)
+        self._generate_schedule4()
+        
+        self.state = 'computed'
+        
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Success',
+                'message': f'Generated annual data for year {self.year}',
+                'type': 'success',
+                'sticky': False,
+            }
+        }
+    
+    def _generate_schedule1(self):
+        """Generate Schedule 1 from monthly/quarterly tax remittances"""
+        Schedule1 = self.env['bir.1604e.schedule1']
+        
+        # Try to get data from BIR 1601-EQ forms if module is installed
+        if 'bir.1601eq' in self.env:
+            forms_1601eq = self.env['bir.1601eq'].search([
+                ('year', '=', self.year),
+                ('company_id', '=', self.company_id.id),
+                ('state', '=', 'submitted')
+            ])
+            
+            # Group by quarter and aggregate monthly data
+            months_data = {}
+            for form in forms_1601eq:
+                quarter_map = {
+                    '1': [(1, 'JAN'), (2, 'FEB'), (3, 'MAR')],
+                    '2': [(4, 'APR'), (5, 'MAY'), (6, 'JUN')],
+                    '3': [(7, 'JUL'), (8, 'AUG'), (9, 'SEPT')],
+                    '4': [(10, 'OCT'), (11, 'NOV'), (12, 'DEC')]
+                }
+                
+                if form.quarter in quarter_map:
+                    # Distribute quarterly amount across months (simplified)
+                    monthly_amount = form.tax_withheld_current_month / 3
+                    for month_num, month_name in quarter_map[form.quarter]:
+                        months_data[month_num] = {
+                            'month': month_name,
+                            'taxes': monthly_amount,
+                            'penalties': form.penalties / 3 if form.penalties else 0.0
+                        }
+        else:
+            # If no 1601-EQ module, create empty monthly entries
+            month_names = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 
+                          'JUL', 'AUG', 'SEPT', 'OCT', 'NOV', 'DEC']
+            for idx, month in enumerate(month_names, 1):
+                months_data[idx] = {
+                    'month': month,
+                    'taxes': 0.0,
+                    'penalties': 0.0
+                }
+        
+        # Create Schedule 1 lines
+        for month_num in sorted(months_data.keys()):
+            data = months_data[month_num]
+            Schedule1.create({
+                'form_id': self.id,
+                'month': data['month'],
+                'date_remittance': date(self.year, month_num, 1),
+                'taxes_withheld': data['taxes'],
+                'penalties': data['penalties'],
+            })
+    
+    def _generate_schedule2(self):
+        """Generate Schedule 2 from Form 1606 data"""
+        Schedule2 = self.env['bir.1604e.schedule2']
+        
+        # Create monthly entries (can be populated from actual 1606 data if available)
+        month_names = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 
+                      'JUL', 'AUG', 'SEPT', 'OCT', 'NOV', 'DEC']
+        
+        for idx, month in enumerate(month_names, 1):
+            Schedule2.create({
+                'form_id': self.id,
+                'month': month,
+                'date_remittance': date(self.year, idx, 1),
+                'taxes_withheld': 0.0,
+                'penalties': 0.0,
+            })
+    
+    def _generate_schedule3(self):
+        """Generate Schedule 3: Payees exempt from withholding tax"""
+        Schedule3 = self.env['bir.1604e.schedule3']
+        
+        # Query vendor bills that are exempt from withholding
+        AccountMove = self.env['account.move']
+        bills = AccountMove.search([
+            ('move_type', '=', 'in_invoice'),
+            ('date', '>=', self.date_from),
+            ('date', '<=', self.date_to),
+            ('state', '=', 'posted'),
+            ('company_id', '=', self.company_id.id),
+        ])
+        
+        # Group by partner
+        partner_data = {}
+        for bill in bills:
+            partner = bill.partner_id
+            if partner.id not in partner_data:
+                partner_data[partner.id] = {
+                    'partner_id': partner.id,
+                    'tin': partner.vat or '',
+                    'name': partner.name,
+                    'amount': 0.0
+                }
+            partner_data[partner.id]['amount'] += bill.amount_total
+        
+        # Create Schedule 3 lines (limit to sample for demonstration)
+        seq = 1
+        for partner_id, data in list(partner_data.items())[:100]:  # Limit for demo
+            Schedule3.create({
+                'form_id': self.id,
+                'sequence': seq,
+                'tin': data['tin'],
+                'payee_name': data['name'],
+                'atc_code': 'WI010',  # Default ATC, should be configurable
+                'nature_income': 'Professional Fees',
+                'income_payment': data['amount'],
+            })
+            seq += 1
+    
+    def _generate_schedule4(self):
+        """Generate Schedule 4: Payees subject to expanded withholding tax"""
+        Schedule4 = self.env['bir.1604e.schedule4']
+        
+        # Query vendor bills with withholding tax
+        AccountMove = self.env['account.move']
+        bills = AccountMove.search([
+            ('move_type', '=', 'in_invoice'),
+            ('date', '>=', self.date_from),
+            ('date', '<=', self.date_to),
+            ('state', '=', 'posted'),
+            ('company_id', '=', self.company_id.id),
+        ])
+        
+        # Group by partner
+        partner_data = {}
+        for bill in bills:
+            partner = bill.partner_id
+            
+            # Look for withholding tax in bill lines
+            wht_amount = 0.0
+            base_amount = bill.amount_untaxed
+            
+            # Try to find withholding tax lines
+            for line in bill.line_ids:
+                if 'withholding' in (line.name or '').lower() or 'ewt' in (line.name or '').lower():
+                    wht_amount += abs(line.balance)
+            
+            if partner.id not in partner_data:
+                partner_data[partner.id] = {
+                    'partner_id': partner.id,
+                    'tin': partner.vat or '',
+                    'name': partner.name,
+                    'amount': 0.0,
+                    'wht': 0.0
+                }
+            partner_data[partner.id]['amount'] += base_amount
+            partner_data[partner.id]['wht'] += wht_amount
+        
+        # Create Schedule 4 lines
+        seq = 1
+        for partner_id, data in list(partner_data.items())[:100]:  # Limit for demo
+            tax_rate = (data['wht'] / data['amount'] * 100) if data['amount'] > 0 else 0.0
+            
+            Schedule4.create({
+                'form_id': self.id,
+                'sequence': seq,
+                'tin': data['tin'],
+                'payee_name': data['name'],
+                'atc_code': 'WC010',  # Default ATC
+                'nature_income': 'Professional Fees',
+                'income_payment': data['amount'],
+                'tax_rate': tax_rate,
+            })
+            seq += 1
+    
+    def action_export_excel(self):
+        """Export to Excel matching BIR 1604-E format"""
+        self.ensure_one()
+        
+        # Create Excel file in memory
+        output = BytesIO()
+        workbook = xlsxwriter.Workbook(output, {'in_memory': True})
+        
+        # Define formats
+        header_format = workbook.add_format({
+            'bold': True,
+            'align': 'center',
+            'valign': 'vcenter',
+            'border': 1,
+            'bg_color': '#D3D3D3'
+        })
+        
+        title_format = workbook.add_format({
+            'bold': True,
+            'font_size': 12,
+            'align': 'center',
+            'valign': 'vcenter'
+        })
+        
+        label_format = workbook.add_format({
+            'bold': True,
+            'align': 'left',
+            'border': 1
+        })
+        
+        data_format = workbook.add_format({
+            'align': 'right',
+            'border': 1,
+            'num_format': '#,##0.00'
+        })
+        
+        text_format = workbook.add_format({
+            'align': 'left',
+            'border': 1
+        })
+        
+        center_format = workbook.add_format({
+            'align': 'center',
+            'border': 1
+        })
+        
+        # Main Sheet
+        sheet = workbook.add_worksheet('BIR Form 1604-E')
+        sheet.set_column('A:A', 8)
+        sheet.set_column('B:C', 12)
+        sheet.set_column('D:P', 15)
+        
+        row = 0
+        
+        # Header
+        sheet.write(row, 0, '(To be filled up by the BIR)', text_format)
+        row += 1
+        sheet.write(row, 1, 'DLN:', label_format)
+        sheet.write(row, 24, 'PSOC:', label_format)
+        row += 2
+        
+        # Instructions
+        sheet.write(row, 0, 'Fill in all applicable spaces. Mark all appropriate boxes with an "X".', text_format)
+        row += 1
+        
+        # Basic Info Row
+        sheet.write(row, 0, '1', center_format)
+        sheet.write(row, 1, 'For the Year', label_format)
+        sheet.write(row, 12, '2', center_format)
+        sheet.write(row, 13, 'Amended Return?', label_format)
+        sheet.write(row, 24, '3', center_format)
+        sheet.write(row, 25, 'No of Sheets Attached', label_format)
+        row += 1
+        
+        sheet.write(row, 1, str(self.year), center_format)
+        sheet.write(row, 20, 'X' if self.amended_return else '', center_format)
+        sheet.write(row, 23, 'X' if not self.amended_return else '', center_format)
+        sheet.write(row, 25, self.num_sheets_attached, center_format)
+        row += 1
+        
+        # Part I: Background Information
+        sheet.merge_range(row, 0, row, 4, 'Part I - Background Information', title_format)
+        row += 1
+        
+        sheet.write(row, 0, '4', center_format)
+        sheet.write(row, 1, 'TIN', label_format)
+        sheet.write(row, 17, '5', center_format)
+        sheet.write(row, 18, 'RDO Code', label_format)
+        sheet.write(row, 23, '6', center_format)
+        sheet.write(row, 24, 'Line of Business/Occupation', label_format)
+        row += 1
+        
+        sheet.write(row, 1, self.tin or '', text_format)
+        sheet.write(row, 18, self.rdo_code or '', text_format)
+        sheet.write(row, 24, self.line_of_business or '', text_format)
+        row += 2
+        
+        sheet.write(row, 0, '7', center_format)
+        sheet.write(row, 1, 'Withholding Agent Name', label_format)
+        row += 1
+        sheet.merge_range(row, 1, row, 10, self.withholding_agent_name or '', text_format)
+        row += 2
+        
+        sheet.write(row, 0, '9', center_format)
+        sheet.write(row, 1, 'Registered Address', label_format)
+        row += 1
+        sheet.merge_range(row, 1, row, 15, self.registered_address or '', text_format)
+        row += 2
+        
+        sheet.write(row, 0, '11', center_format)
+        sheet.write(row, 1, 'Category of Withholding Agent', label_format)
+        sheet.write(row, 12, 'X' if self.category_private else '', center_format)
+        sheet.write(row, 13, 'Private', text_format)
+        sheet.write(row, 16, 'X' if self.category_government else '', center_format)
+        sheet.write(row, 17, 'Government', text_format)
+        row += 2
+        
+        # Part II: Summary of Remittances
+        sheet.merge_range(row, 0, row, 10, 'Part II - Summary of Remittances', title_format)
+        row += 1
+        
+        # Schedule 1: Form 1601-E
+        sheet.write(row, 0, 'Schedule 1', label_format)
+        sheet.merge_range(row, 5, row, 10, 'Remittance per BIR Form No. 1601-E', title_format)
+        row += 1
+        
+        # Schedule 1 Headers
+        sheet.write(row, 0, 'MONTH', header_format)
+        sheet.merge_range(row, 3, row, 3, 'DATE OF REMITTANCE', header_format)
+        sheet.merge_range(row, 7, row, 15, 'NAME OF BANK/BANKCODE/ROR NO., IF ANY', header_format)
+        sheet.merge_range(row, 16, row, 23, 'TAXES WITHHELD', header_format)
+        sheet.merge_range(row, 24, row, 27, 'PENALTIES', header_format)
+        sheet.merge_range(row, 28, row, 30, 'TOTAL AMOUNT REMITTED', header_format)
+        row += 1
+        
+        # Schedule 1 Data
+        for line in self.schedule1_line_ids:
+            sheet.write(row, 0, line.month, text_format)
+            sheet.write(row, 3, line.date_remittance.strftime('%m/%d/%Y') if line.date_remittance else '', text_format)
+            sheet.write(row, 7, line.bank_name or '', text_format)
+            sheet.write(row, 16, line.taxes_withheld, data_format)
+            sheet.write(row, 24, line.penalties, data_format)
+            sheet.write(row, 28, line.total_remitted, data_format)
+            row += 1
+        
+        # Schedule 1 Total
+        sheet.write(row, 0, 'Total', label_format)
+        sheet.write(row, 16, self.total_1601e_taxes, data_format)
+        sheet.write(row, 24, self.total_1601e_penalties, data_format)
+        sheet.write(row, 28, self.total_1601e_remitted, data_format)
+        row += 2
+        
+        # Schedule 2: Form 1606
+        sheet.write(row, 0, 'Schedule 2', label_format)
+        sheet.merge_range(row, 5, row, 10, 'Remittance per BIR Form No. 1606', title_format)
+        row += 1
+        
+        # Schedule 2 Headers
+        sheet.write(row, 0, 'MONTH', header_format)
+        sheet.merge_range(row, 3, row, 3, 'DATE OF REMITTANCE', header_format)
+        sheet.merge_range(row, 7, row, 15, 'NAME OF BANK/BANKCODE/ROR NO., IF ANY', header_format)
+        sheet.merge_range(row, 16, row, 23, 'TAXES WITHHELD', header_format)
+        sheet.merge_range(row, 24, row, 27, 'PENALTIES', header_format)
+        sheet.merge_range(row, 28, row, 30, 'TOTAL AMOUNT REMITTED', header_format)
+        row += 1
+        
+        # Schedule 2 Data
+        for line in self.schedule2_line_ids:
+            sheet.write(row, 0, line.month, text_format)
+            sheet.write(row, 3, line.date_remittance.strftime('%m/%d/%Y') if line.date_remittance else '', text_format)
+            sheet.write(row, 7, line.bank_name or '', text_format)
+            sheet.write(row, 16, line.taxes_withheld, data_format)
+            sheet.write(row, 24, line.penalties, data_format)
+            sheet.write(row, 28, line.total_remitted, data_format)
+            row += 1
+        
+        # Schedule 2 Total
+        sheet.write(row, 0, 'Total', label_format)
+        sheet.write(row, 16, self.total_1606_taxes, data_format)
+        sheet.write(row, 24, self.total_1606_penalties, data_format)
+        sheet.write(row, 28, self.total_1606_remitted, data_format)
+        row += 2
+        
+        # Signatory Section
+        sheet.write(row, 2, '12', center_format)
+        sheet.write(row, 4, self.signatory_name or '', text_format)
+        sheet.write(row, 21, '13', center_format)
+        sheet.write(row, 22, self.signatory_title or '', text_format)
+        row += 1
+        sheet.merge_range(row, 3, row, 15, "Taxpayer/Authorized Agent Signature over Printed Name", label_format)
+        sheet.merge_range(row, 22, row, 27, "Title/Position of Signatory", label_format)
+        
+        # Sheet 2: Schedule 3
+        sheet3 = workbook.add_worksheet('Schedule 3')
+        sheet3.set_column('A:A', 6)
+        sheet3.set_column('B:G', 12)
+        sheet3.set_column('H:R', 20)
+        
+        row3 = 0
+        sheet3.merge_range(row3, 0, row3, 30, 'Schedule 3: ALPHALIST OF OTHER PAYEES WHOSE INCOME PAYMENTS ARE EXEMPT FROM WITHHOLDING TAX', title_format)
+        row3 += 1
+        
+        # Headers
+        sheet3.write(row3, 0, 'SEQ NO.', header_format)
+        sheet3.merge_range(row3, 2, row3, 7, 'Taxpayer Identification Number (TIN)', header_format)
+        sheet3.merge_range(row3, 8, row3, 17, 'NAME OF PAYEES', header_format)
+        sheet3.write(row3, 18, 'ATC', header_format)
+        sheet3.merge_range(row3, 21, row3, 25, 'NATURE OF INCOME PAYMENT', header_format)
+        sheet3.merge_range(row3, 27, row3, 30, 'AMOUNT OF INCOME PAYMENT', header_format)
+        row3 += 1
+        
+        # Schedule 3 Data
+        for line in self.schedule3_line_ids:
+            sheet3.write(row3, 0, line.sequence, center_format)
+            sheet3.write(row3, 2, line.tin or '', text_format)
+            sheet3.write(row3, 8, line.payee_name, text_format)
+            sheet3.write(row3, 18, line.atc_code, text_format)
+            sheet3.write(row3, 21, line.nature_income, text_format)
+            sheet3.write(row3, 27, line.income_payment, data_format)
+            row3 += 1
+        
+        # Sheet 3: Schedule 4
+        sheet4 = workbook.add_worksheet('Schedule 4')
+        sheet4.set_column('A:A', 6)
+        sheet4.set_column('B:G', 12)
+        sheet4.set_column('H:R', 20)
+        
+        row4 = 0
+        sheet4.merge_range(row4, 0, row4, 30, 'Schedule 4: Alphalist of Payees Subject to Expanded Withholding Tax', title_format)
+        row4 += 1
+        
+        # Headers
+        sheet4.write(row4, 0, 'SEQ NO.', header_format)
+        sheet4.merge_range(row4, 2, row4, 7, 'TAXPAYER IDENTIFICATION NUMBER (TIN)', header_format)
+        sheet4.merge_range(row4, 8, row4, 17, 'NAME OF PAYEES', header_format)
+        sheet4.write(row4, 18, 'ATC', header_format)
+        sheet4.merge_range(row4, 21, row4, 25, 'NATURE OF INCOME PAYMENT', header_format)
+        sheet4.merge_range(row4, 27, row4, 30, 'AMOUNT OF INCOME PAYMENT', header_format)
+        sheet4.write(row4, 31, 'RATE OF TAX', header_format)
+        row4 += 1
+        
+        # Schedule 4 Data
+        for line in self.schedule4_line_ids:
+            sheet4.write(row4, 0, line.sequence, center_format)
+            sheet4.write(row4, 2, line.tin or '', text_format)
+            sheet4.write(row4, 8, line.payee_name, text_format)
+            sheet4.write(row4, 18, line.atc_code, text_format)
+            sheet4.write(row4, 21, line.nature_income, text_format)
+            sheet4.write(row4, 27, line.income_payment, data_format)
+            sheet4.write(row4, 31, line.tax_rate, data_format)
+            row4 += 1
+        
+        # Close workbook and save
+        workbook.close()
+        output.seek(0)
+        
+        # Save to record
+        filename = f'BIR_1604E_{self.year}_{self.company_id.name}.xlsx'
+        self.write({
+            'excel_file': base64.b64encode(output.read()),
+            'excel_filename': filename
+        })
+        
+        # Return download action
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/web/content/bir.1604e/{self.id}/excel_file/{filename}?download=true',
+            'target': 'self',
+        }
+    
+    def action_reset_to_draft(self):
+        self.state = 'draft'
+    
+    def action_submit(self):
+        self.state = 'submitted'
+
+
+class BIR1604ESchedule1(models.Model):
+    _name = 'bir.1604e.schedule1'
+    _description = 'BIR 1604-E Schedule 1 - Form 1601-E Remittances'
+    _order = 'form_id, month'
+    
+    form_id = fields.Many2one('bir.1604e', string='Form', required=True, ondelete='cascade')
+    month = fields.Selection([
+        ('JAN', 'January'),
+        ('FEB', 'February'),
+        ('MAR', 'March'),
+        ('APR', 'April'),
+        ('MAY', 'May'),
+        ('JUN', 'June'),
+        ('JUL', 'July'),
+        ('AUG', 'August'),
+        ('SEPT', 'September'),
+        ('OCT', 'October'),
+        ('NOV', 'November'),
+        ('DEC', 'December'),
+    ], string='Month', required=True)
+    date_remittance = fields.Date(string='Date of Remittance')
+    bank_name = fields.Char(string='Bank Name/Bank Code/ROR No.')
+    taxes_withheld = fields.Float(string='Taxes Withheld')
+    penalties = fields.Float(string='Penalties')
+    total_remitted = fields.Float(string='Total Amount Remitted', compute='_compute_total', store=True)
+    
+    @api.depends('taxes_withheld', 'penalties')
+    def _compute_total(self):
+        for record in self:
+            record.total_remitted = record.taxes_withheld + record.penalties
+
+
+class BIR1604ESchedule2(models.Model):
+    _name = 'bir.1604e.schedule2'
+    _description = 'BIR 1604-E Schedule 2 - Form 1606 Remittances'
+    _order = 'form_id, month'
+    
+    form_id = fields.Many2one('bir.1604e', string='Form', required=True, ondelete='cascade')
+    month = fields.Selection([
+        ('JAN', 'January'),
+        ('FEB', 'February'),
+        ('MAR', 'March'),
+        ('APR', 'April'),
+        ('MAY', 'May'),
+        ('JUN', 'June'),
+        ('JUL', 'July'),
+        ('AUG', 'August'),
+        ('SEPT', 'September'),
+        ('OCT', 'October'),
+        ('NOV', 'November'),
+        ('DEC', 'December'),
+    ], string='Month', required=True)
+    date_remittance = fields.Date(string='Date of Remittance')
+    bank_name = fields.Char(string='Bank Name/Bank Code/ROR No.')
+    taxes_withheld = fields.Float(string='Taxes Withheld')
+    penalties = fields.Float(string='Penalties')
+    total_remitted = fields.Float(string='Total Amount Remitted', compute='_compute_total', store=True)
+    
+    @api.depends('taxes_withheld', 'penalties')
+    def _compute_total(self):
+        for record in self:
+            record.total_remitted = record.taxes_withheld + record.penalties
+
+
+class BIR1604ESchedule3(models.Model):
+    _name = 'bir.1604e.schedule3'
+    _description = 'BIR 1604-E Schedule 3 - Exempt from Withholding'
+    _order = 'form_id, sequence'
+    
+    form_id = fields.Many2one('bir.1604e', string='Form', required=True, ondelete='cascade')
+    sequence = fields.Integer(string='Seq No.', required=True)
+    tin = fields.Char(string='TIN')
+    payee_name = fields.Char(string='Name of Payee', required=True)
+    atc_code = fields.Char(string='ATC')
+    nature_income = fields.Char(string='Nature of Income Payment')
+    income_payment = fields.Float(string='Amount of Income Payment')
+
+
+class BIR1604ESchedule4(models.Model):
+    _name = 'bir.1604e.schedule4'
+    _description = 'BIR 1604-E Schedule 4 - Expanded Withholding Tax'
+    _order = 'form_id, sequence'
+    
+    form_id = fields.Many2one('bir.1604e', string='Form', required=True, ondelete='cascade')
+    sequence = fields.Integer(string='Seq No.', required=True)
+    tin = fields.Char(string='TIN')
+    payee_name = fields.Char(string='Name of Payee', required=True)
+    atc_code = fields.Char(string='ATC')
+    nature_income = fields.Char(string='Nature of Income Payment')
+    income_payment = fields.Float(string='Amount of Income Payment')
+    tax_rate = fields.Float(string='Rate of Tax (%)')

--- a/report/bir_1604e_report.xml
+++ b/report/bir_1604e_report.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Report Action -->
+    <record id="action_report_bir_1604e" model="ir.actions.report">
+        <field name="name">BIR Form 1604-E Report</field>
+        <field name="model">bir.1604e</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">bir_form_1604e.report_bir_1604e_document</field>
+        <field name="report_file">bir_form_1604e.report_bir_1604e_document</field>
+        <field name="binding_model_id" ref="model_bir_1604e"/>
+        <field name="binding_type">report</field>
+    </record>
+
+    <!-- Report Template -->
+    <template id="report_bir_1604e_document">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="doc">
+                <t t-call="web.external_layout">
+                    <div class="page">
+                        <div class="text-center">
+                            <h2>BIR FORM 1604-E</h2>
+                            <h4>Annual Information Return of Creditable Income Taxes Withheld (Expanded)</h4>
+                            <h4>Income Payments Exempt From Withholding Tax</h4>
+                        </div>
+                        
+                        <div class="row mt-4">
+                            <div class="col-6">
+                                <strong>Year:</strong> <span t-field="doc.year"/><br/>
+                                <strong>TIN:</strong> <span t-field="doc.tin"/><br/>
+                                <strong>Withholding Agent:</strong> <span t-field="doc.withholding_agent_name"/><br/>
+                                <strong>Registered Address:</strong> <span t-field="doc.registered_address"/><br/>
+                            </div>
+                            <div class="col-6">
+                                <strong>RDO Code:</strong> <span t-field="doc.rdo_code"/><br/>
+                                <strong>Line of Business:</strong> <span t-field="doc.line_of_business"/><br/>
+                                <strong>Amended Return:</strong> <span t-if="doc.amended_return">Yes</span><span t-else="">No</span><br/>
+                                <strong>Sheets Attached:</strong> <span t-field="doc.num_sheets_attached"/><br/>
+                            </div>
+                        </div>
+                        
+                        <h4 class="mt-4">Part II: Summary of Remittances</h4>
+                        
+                        <h5 class="mt-3">Schedule 1: Remittance per BIR Form No. 1601-E</h5>
+                        <table class="table table-sm table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Month</th>
+                                    <th>Date of Remittance</th>
+                                    <th>Bank Name/Bank Code/ROR No.</th>
+                                    <th class="text-right">Taxes Withheld</th>
+                                    <th class="text-right">Penalties</th>
+                                    <th class="text-right">Total Remitted</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="doc.schedule1_line_ids" t-as="line">
+                                    <td><span t-field="line.month"/></td>
+                                    <td><span t-field="line.date_remittance"/></td>
+                                    <td><span t-field="line.bank_name"/></td>
+                                    <td class="text-right"><span t-field="line.taxes_withheld" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="line.penalties" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="line.total_remitted" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                                <tr class="font-weight-bold">
+                                    <td colspan="3" class="text-right">TOTAL:</td>
+                                    <td class="text-right"><span t-field="doc.total_1601e_taxes" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="doc.total_1601e_penalties" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="doc.total_1601e_remitted" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        
+                        <h5 class="mt-3">Schedule 2: Remittance per BIR Form No. 1606</h5>
+                        <table class="table table-sm table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Month</th>
+                                    <th>Date of Remittance</th>
+                                    <th>Bank Name/Bank Code/ROR No.</th>
+                                    <th class="text-right">Taxes Withheld</th>
+                                    <th class="text-right">Penalties</th>
+                                    <th class="text-right">Total Remitted</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="doc.schedule2_line_ids" t-as="line">
+                                    <td><span t-field="line.month"/></td>
+                                    <td><span t-field="line.date_remittance"/></td>
+                                    <td><span t-field="line.bank_name"/></td>
+                                    <td class="text-right"><span t-field="line.taxes_withheld" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="line.penalties" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="line.total_remitted" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                                <tr class="font-weight-bold">
+                                    <td colspan="3" class="text-right">TOTAL:</td>
+                                    <td class="text-right"><span t-field="doc.total_1606_taxes" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="doc.total_1606_penalties" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="doc.total_1606_remitted" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        
+                        <div style="page-break-before: always;"/>
+                        
+                        <h4 class="mt-4">Part III: Alphabetical Lists of Payees</h4>
+                        
+                        <h5 class="mt-3">Schedule 3: Payees Exempt from Withholding Tax</h5>
+                        <table class="table table-sm table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Seq</th>
+                                    <th>TIN</th>
+                                    <th>Name of Payee</th>
+                                    <th>ATC</th>
+                                    <th>Nature of Income</th>
+                                    <th class="text-right">Amount</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="doc.schedule3_line_ids[:50]" t-as="line">
+                                    <td><span t-field="line.sequence"/></td>
+                                    <td><span t-field="line.tin"/></td>
+                                    <td><span t-field="line.payee_name"/></td>
+                                    <td><span t-field="line.atc_code"/></td>
+                                    <td><span t-field="line.nature_income"/></td>
+                                    <td class="text-right"><span t-field="line.income_payment" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                                <t t-if="len(doc.schedule3_line_ids) > 50">
+                                    <tr>
+                                        <td colspan="6" class="text-center font-italic">
+                                            ... and <t t-esc="len(doc.schedule3_line_ids) - 50"/> more payees (see Excel export for complete list)
+                                        </td>
+                                    </tr>
+                                </t>
+                                <tr class="font-weight-bold">
+                                    <td colspan="5" class="text-right">TOTAL:</td>
+                                    <td class="text-right"><span t-field="doc.total_schedule3_amount" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        
+                        <h5 class="mt-3">Schedule 4: Payees Subject to Expanded Withholding Tax</h5>
+                        <table class="table table-sm table-bordered">
+                            <thead>
+                                <tr>
+                                    <th>Seq</th>
+                                    <th>TIN</th>
+                                    <th>Name of Payee</th>
+                                    <th>ATC</th>
+                                    <th>Nature of Income</th>
+                                    <th class="text-right">Amount</th>
+                                    <th class="text-right">Tax Rate</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr t-foreach="doc.schedule4_line_ids[:50]" t-as="line">
+                                    <td><span t-field="line.sequence"/></td>
+                                    <td><span t-field="line.tin"/></td>
+                                    <td><span t-field="line.payee_name"/></td>
+                                    <td><span t-field="line.atc_code"/></td>
+                                    <td><span t-field="line.nature_income"/></td>
+                                    <td class="text-right"><span t-field="line.income_payment" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td class="text-right"><span t-field="line.tax_rate"/>%</td>
+                                </tr>
+                                <t t-if="len(doc.schedule4_line_ids) > 50">
+                                    <tr>
+                                        <td colspan="7" class="text-center font-italic">
+                                            ... and <t t-esc="len(doc.schedule4_line_ids) - 50"/> more payees (see Excel export for complete list)
+                                        </td>
+                                    </tr>
+                                </t>
+                                <tr class="font-weight-bold">
+                                    <td colspan="5" class="text-right">TOTAL:</td>
+                                    <td class="text-right"><span t-field="doc.total_schedule4_income" t-options="{'widget': 'monetary', 'display_currency': doc.company_id.currency_id}"/></td>
+                                    <td></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        
+                        <div class="mt-4">
+                            <p><strong>Signatory Name:</strong> <span t-field="doc.signatory_name"/></p>
+                            <p><strong>Title/Position:</strong> <span t-field="doc.signatory_title"/></p>
+                            <p><strong>Report Date:</strong> <span t-field="doc.report_date"/></p>
+                        </div>
+                    </div>
+                </t>
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -12,3 +12,8 @@ access_bir_1702q,access_bir_1702q,model_bir_1702q,,1,1,1,1
 access_bir_2550q,access_bir_2550q,model_bir_2550q,,1,1,1,1
 access_bir_1601eq,access_bir_1601eq,model_bir_1601eq,,1,1,1,1
 access_bir_1601eq_line,bir.1601eq.line,model_bir_1601eq_line,,1,1,1,1
+access_bir_1604e,Access BIR 1604-E,model_bir_1604e,base.group_user,1,1,1,1
+access_bir_1604e_schedule1,Access BIR 1604-E Schedule 1,model_bir_1604e_schedule1,base.group_user,1,1,1,1
+access_bir_1604e_schedule2,Access BIR 1604-E Schedule 2,model_bir_1604e_schedule2,base.group_user,1,1,1,1
+access_bir_1604e_schedule3,Access BIR 1604-E Schedule 3,model_bir_1604e_schedule3,base.group_user,1,1,1,1
+access_bir_1604e_schedule4,Access BIR 1604-E Schedule 4,model_bir_1604e_schedule4,base.group_user,1,1,1,1

--- a/views/bir_1604e_views.xml
+++ b/views/bir_1604e_views.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Tree View -->
+    <record id="view_bir_1604e_tree" model="ir.ui.view">
+        <field name="name">bir.1604e.tree</field>
+        <field name="model">bir.1604e</field>
+        <field name="arch" type="xml">
+            <list string="BIR Form 1604-E" decoration-info="state=='draft'" decoration-success="state=='computed'" decoration-muted="state=='submitted'">
+                <field name="name"/>
+                <field name="year"/>
+                <field name="company_id"/>
+                <field name="total_1601e_remitted" sum="Total 1601-E"/>
+                <field name="total_1606_remitted" sum="Total 1606"/>
+                <field name="state" widget="badge" decoration-info="state=='draft'" decoration-success="state=='computed'" decoration-muted="state=='submitted'"/>
+            </list>
+        </field>
+    </record>
+
+    <!-- Form View -->
+    <record id="view_bir_1604e_form" model="ir.ui.view">
+        <field name="name">bir.1604e.form</field>
+        <field name="model">bir.1604e</field>
+        <field name="arch" type="xml">
+            <form string="BIR Form 1604-E">
+                <header>
+                    <button name="action_generate_data" string="Generate Data" type="object" 
+                            class="oe_highlight" invisible="state != 'draft'"/>
+                    <button name="action_export_excel" string="Export to Excel" type="object" 
+                            class="oe_highlight" invisible="state == 'draft'"/>
+                    <button name="action_submit" string="Mark as Submitted" type="object" 
+                            invisible="state != 'computed'"/>
+                    <button name="action_reset_to_draft" string="Reset to Draft" type="object" 
+                            invisible="state == 'draft'"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,computed,submitted"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_export_excel" type="object" class="oe_stat_button" icon="fa-download" 
+                                invisible="excel_file == False">
+                            <field name="excel_filename" widget="statinfo" string="Download"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" readonly="1"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group name="period_info" string="Period Information">
+                            <field name="year"/>
+                            <field name="date_from" readonly="1"/>
+                            <field name="date_to" readonly="1"/>
+                            <field name="report_date"/>
+                            <field name="amended_return"/>
+                            <field name="num_sheets_attached" readonly="1"/>
+                        </group>
+                        <group name="company_info" string="Company Information">
+                            <field name="company_id" options="{'no_create': True}"/>
+                            <field name="tin"/>
+                            <field name="withholding_agent_name"/>
+                            <field name="registered_address"/>
+                            <field name="rdo_code"/>
+                            <field name="line_of_business"/>
+                        </group>
+                    </group>
+                    
+                    <group string="Category">
+                        <group>
+                            <field name="category_private"/>
+                        </group>
+                        <group>
+                            <field name="category_government"/>
+                        </group>
+                    </group>
+                    
+                    <notebook>
+                        <page string="Schedule 1: Form 1601-E" name="schedule1">
+                            <group>
+                                <group string="Totals">
+                                    <field name="total_1601e_taxes" readonly="1"/>
+                                    <field name="total_1601e_penalties" readonly="1"/>
+                                    <field name="total_1601e_remitted" readonly="1" class="oe_subtotal_footer_separator"/>
+                                </group>
+                            </group>
+                            <field name="schedule1_line_ids">
+                                <list
+                                 editable="bottom">
+                                    <field name="month"/>
+                                    <field name="date_remittance"/>
+                                    <field name="bank_name"/>
+                                    <field name="taxes_withheld" sum="Total Taxes"/>
+                                    <field name="penalties" sum="Total Penalties"/>
+                                    <field name="total_remitted" sum="Total Remitted"/>
+                                </list>
+                            </field>
+                        </page>
+                        
+                        <page string="Schedule 2: Form 1606" name="schedule2">
+                            <group>
+                                <group string="Totals">
+                                    <field name="total_1606_taxes" readonly="1"/>
+                                    <field name="total_1606_penalties" readonly="1"/>
+                                    <field name="total_1606_remitted" readonly="1" class="oe_subtotal_footer_separator"/>
+                                </group>
+                            </group>
+                            <field name="schedule2_line_ids">
+                                <list editable="bottom">
+                                    <field name="month"/>
+                                    <field name="date_remittance"/>
+                                    <field name="bank_name"/>
+                                    <field name="taxes_withheld" sum="Total Taxes"/>
+                                    <field name="penalties" sum="Total Penalties"/>
+                                    <field name="total_remitted" sum="Total Remitted"/>
+                                </list>
+                            </field>
+                        </page>
+                        
+                        <page string="Schedule 3: Exempt from WHT" name="schedule3">
+                            <group>
+                                <group>
+                                    <field name="total_schedule3_amount" readonly="1"/>
+                                </group>
+                            </group>
+                            <field name="schedule3_line_ids">
+                                <list editable="bottom">
+                                    <field name="sequence"/>
+                                    <field name="tin"/>
+                                    <field name="payee_name"/>
+                                    <field name="atc_code"/>
+                                    <field name="nature_income"/>
+                                    <field name="income_payment" sum="Total"/>
+                                </list>
+                            </field>
+                        </page>
+                        
+                        <page string="Schedule 4: Expanded WHT" name="schedule4">
+                            <group>
+                                <group>
+                                    <field name="total_schedule4_income" readonly="1"/>
+                                </group>
+                            </group>
+                            <field name="schedule4_line_ids">
+                                <list editable="bottom">
+                                    <field name="sequence"/>
+                                    <field name="tin"/>
+                                    <field name="payee_name"/>
+                                    <field name="atc_code"/>
+                                    <field name="nature_income"/>
+                                    <field name="income_payment" sum="Total"/>
+                                    <field name="tax_rate"/>
+                                </list>
+                            </field>
+                        </page>
+                        
+                        <page string="Signatory" name="signatory">
+                            <group>
+                                <group>
+                                    <field name="signatory_name"/>
+                                </group>
+                                <group>
+                                    <field name="signatory_title"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+                <chatter />
+            </form>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="view_bir_1604e_search" model="ir.ui.view">
+        <field name="name">bir.1604e.search</field>
+        <field name="model">bir.1604e</field>
+        <field name="arch" type="xml">
+            <search string="BIR Form 1604-E">
+                <field name="name"/>
+                <field name="year"/>
+                <field name="company_id"/>
+                <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]"/>
+                <filter string="Computed" name="computed" domain="[('state', '=', 'computed')]"/>
+                <filter string="Submitted" name="submitted" domain="[('state', '=', 'submitted')]"/>
+                <group expand="0" string="Group By">
+                    <filter string="Year" name="group_year" context="{'group_by': 'year'}"/>
+                    <filter string="Company" name="group_company" context="{'group_by': 'company_id'}"/>
+                    <filter string="Status" name="group_state" context="{'group_by': 'state'}"/>
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <!-- Action -->
+    <record id="action_bir_1604e" model="ir.actions.act_window">
+        <field name="name">BIR Form 1604-E</field>
+        <field name="res_model">bir.1604e</field>
+        <field name="view_mode">list,form</field>
+        <field name="context">{}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new BIR Form 1604-E
+            </p>
+            <p>
+                Generate annual information return of creditable income taxes withheld (expanded).
+            </p>
+        </field>
+    </record>
+
+    <!-- Menu Item -->
+   <!--  <menuitem id="menu_bir_1604e" 
+              name="Form 1604-E" 
+              parent="bir_form_1601eq.menu_bir_forms" 
+              action="action_bir_1604e" 
+              sequence="20"/> -->
+
+    <!-- Sequence -->
+    <record id="sequence_bir_1604e" model="ir.sequence">
+        <field name="name">BIR Form 1604-E</field>
+        <field name="code">bir.1604e</field>
+        <field name="prefix">1604E/</field>
+        <field name="padding">5</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+</odoo>

--- a/views/bir_form_view.xml
+++ b/views/bir_form_view.xml
@@ -78,7 +78,7 @@
         <field name="name">BIR 1604-E-Q</field>
         <field name="category">annual</field>
         <field name="description">Annual Return of Withholding Tax</field>
-        <!-- <field name="action_id" ref="action_bir_1604eq"/> -->
+        <field name="action_id" ref="action_bir_1604e"/>
     </record>
 
      <record id="bir_demo_1702c" model="bir.model">


### PR DESCRIPTION
## Summary by Sourcery

Introduce support for BIR Form 1604-E annual information returns, including data generation, reporting, and export capabilities.

New Features:
- Add bir.1604e models and schedules to manage annual BIR Form 1604-E data with state tracking and signatory details.
- Provide UI list, form, and search views for BIR Form 1604-E with actions to generate data, export to Excel, and mark submissions.
- Add a QWeb PDF report and Excel export for BIR Form 1604-E summarizing remittances and alphalists of payees.
- Wire the existing BIR 1604-E form definition to the new action and register the form in the module manifest.