### PR TITLE
fix company id

### DIFF
--- a/models/bir_2550m.py
+++ b/models/bir_2550m.py
@@ -628,7 +628,6 @@ class Bir2550M(models.Model):
             # ── Capital Goods Purchases → Sch 2 ──
             # Find asset accounts with 'equipment', 'furniture', 'machinery', or 'capital'
             capital_accounts = self.env["account.account"].search([
-                ("company_id", "=", company_id),
                 ("account_type", "in", ["asset_fixed", "asset_non_current"]),
             ])
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure capital asset accounts are correctly retrieved for BIR 2550M capital goods purchases by removing an overly restrictive company filter.