### PR TITLE
feat: add user role for employee own

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -9,6 +9,7 @@
         #Security
         'security/custom_sql_report_security.xml',
         'security/salary_advance_security.xml',
+        'security/security.xml',
         'security/ir.model.access.csv',
 
         #Data

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -28,3 +28,4 @@ access_bir_2550m_sch4,Access BIR 2550M Schedule 4,model_bir_2550m_sch4,base.grou
 access_bir_2550m_sch5,Access BIR 2550M Schedule 5,model_bir_2550m_sch5,base.group_user,1,1,1,1
 access_bir_2550m_sch6,Access BIR 2550M Schedule 6,model_bir_2550m_sch6,base.group_user,1,1,1,1
 access_bir_2550m_sch7,Access BIR 2550M Schedule 7,model_bir_2550m_sch7,base.group_user,1,1,1,1
+access_hr_employee_limited,hr.employee limited access,hr.model_hr_employee,itc_internal_dev.group_limited_employee_access,1,0,0,0

--- a/security/security.xml
+++ b/security/security.xml
@@ -1,0 +1,18 @@
+<odoo>
+
+    <!-- Custom Group -->
+    <record id="group_limited_employee_access" model="res.groups">
+        <field name="name">Limited Employee Access</field>
+        <field name="category_id" ref="base.module_category_human_resources"/>
+    </record>
+    <!-- Record Rule: Only See Own Employee Record -->
+    <record id="rule_hr_employee_own_only" model="ir.rule">
+        <field name="name">Employee Own Record Only</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="groups" eval="[(4, ref('itc_internal_dev.group_limited_employee_access'))]"/>
+        <field name="domain_force">
+            [('user_id', '=', user.id)]
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new limited employee access role that restricts users to viewing only their own employee record.

New Features:
- Add a security group for limited employee access in HR.
- Apply a record rule to restrict employee model visibility to the current user's own record.