### PR TITLE
fix grouip

### DIFF
--- a/security/security.xml
+++ b/security/security.xml
@@ -1,18 +1,15 @@
 <odoo>
 
-    <!-- Custom Group -->
     <record id="group_limited_employee_access" model="res.groups">
         <field name="name">Limited Employee Access</field>
-        <field name="category_id" ref="base.module_category_human_resources"/>
+        <field name="category_id" ref="hr.module_category_hr"/>
     </record>
-    <!-- Record Rule: Only See Own Employee Record -->
+
     <record id="rule_hr_employee_own_only" model="ir.rule">
         <field name="name">Employee Own Record Only</field>
         <field name="model_id" ref="hr.model_hr_employee"/>
         <field name="groups" eval="[(4, ref('itc_internal_dev.group_limited_employee_access'))]"/>
-        <field name="domain_force">
-            [('user_id', '=', user.id)]
-        </field>
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
## Summary by Sourcery

Align employee access security group and rule configuration with the correct HR module category and simplify the record rule domain definition.

Enhancements:
- Assign the limited employee access group to the standard HR module category instead of the generic human resources category.
- Inline and normalize the employee own-record rule domain expression for consistency in security configuration.