### PR TITLE
Initial

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -9,7 +9,7 @@
         #Security
         'security/custom_sql_report_security.xml',
         'security/salary_advance_security.xml',
-        'security/security.xml',
+        #'security/security.xml',
         'security/ir.model.access.csv',
 
         #Data

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -28,4 +28,3 @@ access_bir_2550m_sch4,Access BIR 2550M Schedule 4,model_bir_2550m_sch4,base.grou
 access_bir_2550m_sch5,Access BIR 2550M Schedule 5,model_bir_2550m_sch5,base.group_user,1,1,1,1
 access_bir_2550m_sch6,Access BIR 2550M Schedule 6,model_bir_2550m_sch6,base.group_user,1,1,1,1
 access_bir_2550m_sch7,Access BIR 2550M Schedule 7,model_bir_2550m_sch7,base.group_user,1,1,1,1
-access_hr_employee_limited,hr.employee limited access,hr.model_hr_employee,itc_internal_dev.group_limited_employee_access,1,0,0,0

--- a/security/security.xml
+++ b/security/security.xml
@@ -2,7 +2,7 @@
 
     <record id="group_limited_employee_access" model="res.groups">
         <field name="name">Limited Employee Access</field>
-        <field name="category_id" ref="hr.module_category_hr"/>
+        <field name="category_id" ref="base.module_category_human_resources"/>
     </record>
 
     <record id="rule_hr_employee_own_only" model="ir.rule">


### PR DESCRIPTION
## Summary by Sourcery

Disable a legacy security configuration file and update the HR group category reference in the remaining security definition.

Enhancements:
- Update the Limited Employee Access group to use the standard human resources module category.

Chores:
- Exclude the deprecated security.xml file from the module manifest so it is no longer loaded.