### PR TITLE
fix: onchange vendor tin to compute field

### DIFF
--- a/models/hr_expense.py
+++ b/models/hr_expense.py
@@ -19,7 +19,7 @@ class HrExpense(models.Model):
 
     x_vendor_tin = fields.Char(
         string="Vendor TIN",
-        readonly=True,
+        compute="_compute_vendor_tax_id",
         store=True,
         help="Tax Identification Number of the vendor associated with this expense."
     )
@@ -78,8 +78,8 @@ class HrExpense(models.Model):
     # ----------------------
     # Onchange & Compute
     # ----------------------
-    @api.onchange('vendor_id')
-    def _onchange_vendor_id(self):
+    @api.depends('vendor_id')
+    def _compute_vendor_tax_id(self):
         for record in self:
             record.x_vendor_tin = record.vendor_id.vat or ''
 

--- a/views/expense_view.xml
+++ b/views/expense_view.xml
@@ -14,8 +14,8 @@
 
         <xpath expr="//field[@name='vendor_id']" position="after">
             <field name="x_vendor_tin" invisible="not vendor_id or payment_mode == 'own_account'"/>
-            <field name="x_voucher_amount" widget="monetary"/>
-            <field name="x_payment_amount" widget="monetary"/>
+            <field name="x_voucher_amount" widget="monetary" invisible="True"/>
+            <field name="x_payment_amount" widget="monetary" invisible="True"/>
         </xpath>
 
         <!-- Target the group where the payment_mode belogns to and inject the field you wanna add -->


### PR DESCRIPTION
## Summary by Sourcery

Compute vendor TIN on expenses based on the selected vendor and hide voucher/payment amount fields from the expense form.

Bug Fixes:
- Ensure the vendor TIN field on expenses is always kept in sync by making it a stored computed field depending on the vendor instead of relying on an onchange handler.

Enhancements:
- Hide custom voucher and payment amount fields on the expense form view to prevent them from being edited or displayed.