### PR TITLE
fix discount logic

### DIFF
--- a/models/hr_expense.py
+++ b/models/hr_expense.py
@@ -75,6 +75,15 @@ class HrExpense(models.Model):
         help='Discount amount automatically computed from Discount % and total_amount_currency.',
     )
 
+    x_original_amount = fields.Monetary(
+        string='Original Amount',
+        currency_field='currency_id',
+        compute='_compute_discount_amount',
+        store=True,
+        readonly=True,
+        help='Original amount automatically computed from Discount % and total_amount_currency.',
+    )
+
     # ----------------------
     # Onchange & Compute
     # ----------------------
@@ -86,7 +95,16 @@ class HrExpense(models.Model):
     @api.depends('total_amount_currency', 'x_discount_percentage')
     def _compute_discount_amount(self):
         for rec in self:
-            rec.x_discount_amount = (rec.total_amount_currency or 0) * (rec.x_discount_percentage or 0) / 100
+            discounted = rec.total_amount_currency or 0
+            discount_rate = (rec.x_discount_percentage or 0) / 100
+
+            if discount_rate >= 1:
+                rec.x_discount_amount = 0
+                continue
+
+            original_price = discounted / (1 - discount_rate)
+            rec.x_discount_amount = original_price - discounted
+            rec.x_original_amount = original_price
 
     @api.depends('x_voucher_amount', 'x_voucher')
     def _compute_payment_amount(self):

--- a/views/expense_view.xml
+++ b/views/expense_view.xml
@@ -8,7 +8,8 @@
 
         <xpath expr="//field[@name='employee_id']/.." position="before">
              <field name="x_discount_percentage" string="Discount %"/>
-            <field name="x_discount_amount" string="Discount Amount" readonly="1" widget="monetary"/>
+            <field name="x_discount_amount" string="Discount Amount" readonly="1" invisible='x_discount_percentage == 0' widget="monetary"/>
+            <field name="x_original_amount" string="Original Amount" readonly="1" invisible='x_discount_percentage == 0' widget="monetary"/>
             <field name="x_voucher" />
         </xpath>
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust expense discount computation and expose the original amount before discount on expenses.

New Features:
- Add an `x_original_amount` monetary field on expenses to store the computed original amount before discount.

Bug Fixes:
- Correct discount calculation so the discount amount is derived from the discounted total and discount percentage, and ignore invalid discount rates of 100% or more.

Enhancements:
- Update the expense form view to show the discount and original amount fields only when a non-zero discount percentage is set.