### PR TITLE
fixes for ack receipt

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -57,6 +57,7 @@
         'views/bir_form_view.xml',
         'views/account_payment_view.xml',
         # Change Request modules
+        #'views/account_payment_register_views.xml',
         #'views/cash_advance_views.xml',
         #'views/disbursement_voucher_views.xml',
         #'views/disbursement_voucher_line_views.xml',

--- a/models/account_payment.py
+++ b/models/account_payment.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import api, fields, models, _
 
 class AccountPayment(models.Model):
     _inherit = "account.payment"
@@ -8,3 +8,241 @@ class AccountPayment(models.Model):
         string="Expense Type",
         domain=[('can_be_expensed', '=', True)]
     )
+
+    
+    # ------------------------------------------------------------------
+    # Fields stored on the posted payment
+    # ------------------------------------------------------------------
+    payment_tax_id = fields.Many2one(
+        comodel_name='account.tax',
+        string='Payment Tax',
+        copy=False,
+    )
+    payment_base_amount = fields.Monetary(
+        string='Base Amount (excl. Tax)',
+        currency_field='currency_id',
+        copy=False,
+    )
+    payment_tax_amount = fields.Monetary(
+        string='Tax Amount',
+        currency_field='currency_id',
+        copy=False,
+    )
+ 
+    # ------------------------------------------------------------------
+    # Override: inject tax lines into the journal entry move lines
+    # ------------------------------------------------------------------
+    """ def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None, **kwargs):
+    
+        line_vals_list = super()._prepare_move_line_default_vals(
+            write_off_line_vals=write_off_line_vals,
+            force_balance=force_balance,
+            **kwargs,
+        )
+ 
+        if not self.payment_tax_id or len(line_vals_list) < 2:
+            return line_vals_list
+ 
+        tax = self.payment_tax_id
+        currency = self.currency_id
+ 
+        taxes_res = tax.compute_all(
+            price_unit=self.amount,
+            currency=currency,
+            quantity=1.0,
+            partner=self.partner_id or None,
+        )
+ 
+        base_amount = taxes_res['total_excluded']
+        total_amount = taxes_res['total_included']
+        tax_lines_data = taxes_res.get('taxes', [])
+ 
+        if not tax_lines_data:
+            return line_vals_list
+ 
+        # line_vals_list[0] = liquidity line (bank/cash)
+        # line_vals_list[1] = counterpart line (AR/AP outstanding)
+        liquidity_line = line_vals_list[0]
+        counterpart_line = line_vals_list[1]
+ 
+        sign = 1 if self.payment_type == 'inbound' else -1
+ 
+        # Adjust liquidity line to full total (base + tax)
+        if liquidity_line.get('debit', 0.0):
+            liquidity_line['debit'] = total_amount
+            liquidity_line['credit'] = 0.0
+        else:
+            liquidity_line['credit'] = total_amount
+            liquidity_line['debit'] = 0.0
+        liquidity_line['amount_currency'] = sign * total_amount
+ 
+        # Adjust counterpart line to base only
+        if counterpart_line.get('debit', 0.0):
+            counterpart_line['debit'] = base_amount
+            counterpart_line['credit'] = 0.0
+        else:
+            counterpart_line['credit'] = base_amount
+            counterpart_line['debit'] = 0.0
+        counterpart_line['amount_currency'] = -sign * base_amount
+ 
+        # Add one line per tax component
+        for tax_data in tax_lines_data:
+            tax_amount = abs(tax_data['amount'])
+            if not tax_amount:
+                continue
+ 
+            # Resolve tax account from compute_all result first,
+            # then fall back to the tax's repartition lines
+            tax_account_id = tax_data.get('account_id')
+            if not tax_account_id:
+                repartition = self.env['account.tax.repartition.line'].search([
+                    ('tax_id', '=', tax_data['id']),
+                    ('repartition_type', '=', 'tax'),
+                    ('company_id', '=', self.company_id.id),
+                ], limit=1)
+                tax_account_id = (
+                    repartition.account_id.id
+                    if repartition and repartition.account_id
+                    else counterpart_line.get('account_id')
+                )
+ 
+            # inbound: tax credited (liability); outbound: tax debited (expense/asset)
+            if self.payment_type == 'inbound':
+                tax_debit, tax_credit = 0.0, tax_amount
+                tax_amount_currency = -tax_amount
+            else:
+                tax_debit, tax_credit = tax_amount, 0.0
+                tax_amount_currency = tax_amount
+ 
+            line_vals_list.append({
+                'name': tax_data.get('name', tax.name),
+                'account_id': tax_account_id,
+                'debit': tax_debit,
+                'credit': tax_credit,
+                'amount_currency': tax_amount_currency,
+                'currency_id': currency.id,
+                'partner_id': self.partner_id.id if self.partner_id else False,
+                'tax_base_amount': base_amount,
+                'tax_repartition_line_id': tax_data.get('tax_repartition_line_id'),
+                'tax_ids': [],
+                'tax_tag_ids': tax_data.get('tag_ids', []),
+            })
+ 
+        return line_vals_list """
+ 
+    # ------------------------------------------------------------------
+    # Log tax summary to chatter on post
+    # ------------------------------------------------------------------
+    """ def action_post(self):
+        res = super().action_post()
+        for payment in self.filtered('payment_tax_id'):
+            payment.message_post(body=_(
+                "Tax applied: %(tax)s — Base: %(base)s, Tax: %(tax_amt)s %(currency)s",
+                tax=payment.payment_tax_id.name,
+                base=payment.payment_base_amount,
+                tax_amt=payment.payment_tax_amount,
+                currency=payment.currency_id.name,
+            ))
+        return res
+    """
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = 'account.payment.register'
+
+    # ------------------------------------------------------------------
+    # Fields
+    # ------------------------------------------------------------------
+    tax_id = fields.Many2one(
+        comodel_name='account.tax',
+        string='Tax',
+        domain=[('type_tax_use', 'in', ['sale', 'purchase', 'none'])],
+    )
+    tax_amount = fields.Monetary(
+        string='Tax Amount',
+        compute='_compute_tax_breakdown',
+        currency_field='currency_id',
+    )
+    base_amount = fields.Monetary(
+        string='Base Amount',
+        compute='_compute_tax_breakdown',
+        currency_field='currency_id',
+    )
+    total_with_tax = fields.Monetary(
+        string='Total (incl. Tax)',
+        compute='_compute_tax_breakdown',
+        currency_field='currency_id',
+    )
+    tax_breakdown_ids = fields.One2many(
+        comodel_name='account.payment.register.tax.line',
+        inverse_name='wizard_id',
+        string='Tax Breakdown',
+        compute='_compute_tax_breakdown',
+    )
+
+    # ------------------------------------------------------------------
+    # Compute
+    # ------------------------------------------------------------------
+    """ @api.depends('amount', 'tax_id', 'currency_id', 'partner_id')
+    def _compute_tax_breakdown(self):
+        TaxLine = self.env['account.payment.register.tax.line']
+        for wizard in self:
+            wizard.tax_breakdown_ids = TaxLine
+            wizard.tax_amount = 0.0
+            wizard.base_amount = wizard.amount
+            wizard.total_with_tax = wizard.amount
+
+            if not wizard.tax_id or not wizard.amount:
+                continue
+
+            currency = wizard.currency_id or self.env.company.currency_id
+            taxes_res = wizard.tax_id.compute_all(
+                price_unit=wizard.amount,
+                currency=currency,
+                quantity=1.0,
+                partner=wizard.partner_id or None,
+            )
+
+            wizard.base_amount = taxes_res['total_excluded']
+            wizard.total_with_tax = taxes_res['total_included']
+            wizard.tax_amount = wizard.total_with_tax - wizard.base_amount
+
+            lines = TaxLine
+            for t in taxes_res.get('taxes', []):
+                lines |= TaxLine.new({
+                    'wizard_id': wizard.id,
+                    'tax_id': t['id'],
+                    'name': t['name'],
+                    'base': t['base'],
+                    'amount': t['amount'],
+                    'account_id': t.get('account_id') or False,
+                })
+            wizard.tax_breakdown_ids = lines """
+
+    # ------------------------------------------------------------------
+    # Override: pass tax data into payment vals
+    # ------------------------------------------------------------------
+    """ def _create_payment_vals_from_wizard(self, batch_result):
+        vals = super()._create_payment_vals_from_wizard(batch_result)
+        if self.tax_id:
+            vals['payment_tax_id'] = self.tax_id.id
+            vals['payment_base_amount'] = self.base_amount
+            vals['payment_tax_amount'] = self.tax_amount
+        return vals
+ """
+
+class AccountPaymentRegisterTaxLine(models.TransientModel):
+    _name = 'account.payment.register.tax.line'
+    _description = 'Payment Register Tax Breakdown Line'
+
+    wizard_id = fields.Many2one(
+        comodel_name='account.payment.register',
+        required=True,
+        ondelete='cascade',
+    )
+    tax_id = fields.Many2one('account.tax', string='Tax')
+    name = fields.Char(string='Tax Name')
+    base = fields.Monetary(string='Base Amount', currency_field='currency_id')
+    amount = fields.Monetary(string='Tax Amount', currency_field='currency_id')
+    account_id = fields.Many2one('account.account', string='Tax Account')
+    currency_id = fields.Many2one(related='wizard_id.currency_id')

--- a/report/acknowledgement_report.xml
+++ b/report/acknowledgement_report.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-  <!-- QWeb Template: Official Receipt -->
+  <!-- QWeb Template: Acknowledgement Receipt — model: account.move -->
   <template id="report_custom_acknowledgement_receipt_template">
     <t t-call="web.external_layout">
       <t t-foreach="docs" t-as="doc">
         <div class="page" style="font-family: Arial, sans-serif; font-size: 14px; line-height:1.4;">
           <main>
+
             <!-- Receipt Header -->
             <table style="width:100%; margin-bottom:15px; font-size:13px; border-collapse:collapse;">
               <tr>
@@ -15,57 +16,72 @@
                   <strong>BR:</strong> BR-00000-MAIN
                 </td>
                 <td style="width:40%; vertical-align:bottom; padding:5px; text-align:right; border:1px solid black;">
-                  <strong>AR Date:</strong> <span t-field="doc.date" t-options='{"format": "MMMM dd, yyyy"}'/><br/>
+                  <strong>AR Date:</strong>
+                  <span t-field="doc.invoice_date" t-options='{"format": "MMMM dd, yyyy"}'/><br/>
                 </td>
               </tr>
             </table>
 
-            <!-- Received From Information -->
+            <!-- Received From -->
             <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
               <tr>
                 <td style="border:1px solid black; padding:5px; width:25%;"><strong>Received From:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><span t-field="doc.partner_id.name"/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3">
+                  <span t-field="doc.partner_id.name"/>
+                </td>
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>Address:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><span/><span t-field="doc.partner_id.contact_address_complete"/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3">
+                  <span t-field="doc.partner_id.contact_address_complete"/>
+                </td>
               </tr>
               <tr>
                 <td style="border:1px solid black; padding:5px;"><strong>TIN:</strong></td>
-                <td style="border:1px solid black; padding:5px;" colspan="3"><span t-field="doc.partner_id.vat"/></td>
+                <td style="border:1px solid black; padding:5px;" colspan="3">
+                  <span t-field="doc.partner_id.vat"/>
+                </td>
               </tr>
             </table>
 
-            <!-- Reference Details Table -->
+            <!-- Invoice Lines -->
             <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
               <thead style="background:#f0f0f0;">
                 <tr>
                   <th style="border:1px solid black; padding:5px; text-align:left;">Reference Number</th>
-                  <th style="border:1px solid black; padding:5px; text-align:right; width:100px;">Amount</th>
+                  <th style="border:1px solid black; padding:5px; text-align:right; width:150px;">Amount</th>
                 </tr>
               </thead>
               <tbody>
-                <t t-set="reconciled_invoices" t-value="doc.reconciled_invoice_ids"/>
-                <t t-set="num_invs" t-value="len(reconciled_invoices)"/>
-                <t t-set="rows" t-value="(num_invs + 1) // 2"/>
-                <t t-foreach="range(rows)" t-as="row">
-                  <tr>
-                    <td style="border:1px solid black; padding:5px;"><t t-if="row*2 &lt; num_invs"><span t-field="reconciled_invoices[row*2].name"/></t></td>
-                    <td style="border:1px solid black; padding:5px; text-align:right;"><t t-if="row*2 &lt; num_invs"><span t-field="reconciled_invoices[row*2].amount_total" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></t></td>
-                  </tr>
+                <t t-foreach="doc.invoice_line_ids" t-as="line">
+                  <t t-if="not line.display_type">
+                    <tr>
+                      <td style="border:1px solid black; padding:5px;">
+                        <span t-field="line.name"/>
+                      </td>
+                      <td style="border:1px solid black; padding:5px; text-align:right;">
+                        <span t-field="line.price_subtotal"
+                              t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                      </td>
+                    </tr>
+                  </t>
                 </t>
               </tbody>
               <tfoot>
                 <tr>
                   <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">TOTAL</td>
-                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                    <span t-field="doc.amount_total"
+                          t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                  </td>
                 </tr>
               </tfoot>
             </table>
 
-            <!-- Collection Details and Mode of Payment -->
+            <!-- Collection Details + Mode of Payment -->
             <table style="width:100%; margin-bottom:15px;">
               <tr>
+                <!-- Collection Details -->
                 <td style="width:50%; vertical-align:top; padding-right:5px;">
                   <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px;">
                     <thead style="background:#f0f0f0;">
@@ -74,15 +90,25 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <t t-set="gross_amount" t-value="sum(invoice.amount_total_signed for invoice in doc.reconciled_invoice_ids)"/>
-                      <t t-set="ewt" t-value="gross_amount - doc.amount_signed"/>
+                      <!--
+                        amount_untaxed = subtotal before tax
+                        tax_amount     = total tax
+                        ewt            = difference between gross and amount_residual (what was withheld)
+                      -->
+                      <t t-set="ewt" t-value="doc.amount_total - doc.amount_untaxed - doc.amount_tax"/>
                       <tr>
                         <td style="border:1px solid black; padding:5px;">Amount For Collection</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right;"><span t-esc="gross_amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                        <td style="border:1px solid black; padding:5px; text-align:right;">
+                          <span t-field="doc.amount_total"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                       <tr>
-                        <td style="border:1px solid black; padding:5px;">Less: 2307 - EWT</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right;"><span t-esc="ewt" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                        <td style="border:1px solid black; padding:5px;">Less: EWT</td>
+                        <td style="border:1px solid black; padding:5px; text-align:right;">
+                          <span t-field="doc.amount_tax"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                       <tr>
                         <td style="border:1px solid black; padding:5px;">Less: Other Deductions</td>
@@ -94,11 +120,16 @@
                       </tr>
                       <tr>
                         <td style="border:1px solid black; padding:5px; font-weight:bold;">Total</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                        <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                          <span t-field="doc.amount_untaxed"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
                 </td>
+
+                <!-- Mode of Payment -->
                 <td style="width:50%; vertical-align:top; padding-left:5px;">
                   <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px;">
                     <thead style="background:#f0f0f0;">
@@ -111,13 +142,26 @@
                         <td style="border:1px solid black; padding:5px;">Description</td>
                         <td style="border:1px solid black; padding:5px; text-align:right;">Amount</td>
                       </tr>
+                      <!--
+                        account.move has no direct payment_method field.
+                        We derive mode from the reconciled payments.
+                      -->
+                      <t t-set="payments" t-value="doc._get_reconciled_payments()"/>
+                      <t t-set="cash_amount" t-value="sum(p.amount for p in payments if p.journal_id.type == 'cash')"/>
+                      <t t-set="check_amount" t-value="sum(p.amount for p in payments if p.payment_method_line_id.code == 'check_printing')"/>
                       <tr>
                         <td style="border:1px solid black; padding:5px;">Cash</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right;"><t t-if="doc.payment_method_line_id.code == 'cash'"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></t><t t-else="">0.00</t></td>
+                        <td style="border:1px solid black; padding:5px; text-align:right;">
+                          <span t-esc="cash_amount"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                       <tr>
                         <td style="border:1px solid black; padding:5px;">Check</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right;"><t t-if="doc.payment_method_line_id.code == 'check'"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></t><t t-else="">0.00</t></td>
+                        <td style="border:1px solid black; padding:5px; text-align:right;">
+                          <span t-esc="check_amount"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                       <tr>
                         <td style="border:1px solid black; padding:5px;">Others</td>
@@ -125,7 +169,10 @@
                       </tr>
                       <tr>
                         <td style="border:1px solid black; padding:5px; font-weight:bold;">Total</td>
-                        <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                        <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                          <span t-field="doc.amount_total"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </td>
                       </tr>
                     </tbody>
                   </table>
@@ -134,9 +181,12 @@
             </table>
 
             <!-- Amount in Words -->
-            <p style="margin-bottom:15px;"><strong>Amount in Words:</strong> ***<span t-esc="doc.currency_id.amount_to_text(doc.amount)"/> ONLY***</p>
+            <p style="margin-bottom:15px;">
+              <strong>Amount in Words:</strong>
+              ***<span t-esc="doc.currency_id.amount_to_text(doc.amount_total)"/> ONLY***
+            </p>
 
-            <!-- Payment Details Table -->
+            <!-- Check Details (from reconciled payments) -->
             <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
               <thead style="background:#f0f0f0;">
                 <tr>
@@ -147,22 +197,44 @@
                 </tr>
               </thead>
               <tbody>
-                <tr t-if="doc.payment_method_line_id.code == 'check'">
-                  <td style="border:1px solid black; padding:5px;"><span t-field="doc.journal_id.name"/></td>
-                  <td style="border:1px solid black; padding:5px;"><span t-field="doc.date" t-options='{"format": "MM/dd/yyyy"}'/></td>
-                  <td style="border:1px solid black; padding:5px;"><span t-field="doc.check_number"/></td>
-                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
-                </tr>
+                <t t-set="check_payments" t-value="[p for p in doc._get_reconciled_payments() if p.payment_method_line_id.code == 'check_printing']"/>
+                <t t-if="check_payments">
+                  <t t-foreach="check_payments" t-as="cp">
+                    <tr>
+                      <td style="border:1px solid black; padding:5px;">
+                        <span t-esc="cp.journal_id.bank_id.name"/>
+                      </td>
+                      <td style="border:1px solid black; padding:5px;">
+                        <span t-esc="cp.date" t-options='{"widget": "date", "format": "MM/dd/yyyy"}'/>
+                      </td>
+                      <td style="border:1px solid black; padding:5px;">
+                        <span t-esc="cp.check_number"/>
+                      </td>
+                      <td style="border:1px solid black; padding:5px; text-align:right;">
+                        <span t-esc="cp.amount"
+                              t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                      </td>
+                    </tr>
+                  </t>
+                </t>
+                <t t-else="">
+                  <tr>
+                    <td colspan="4" style="border:1px solid black; padding:5px;"> </td>
+                  </tr>
+                </t>
               </tbody>
               <tfoot>
                 <tr>
                   <td colspan="3" style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">Total</td>
-                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                    <span t-esc="check_amount"
+                          t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                  </td>
                 </tr>
               </tfoot>
             </table>
 
-            <!-- Account Title Table -->
+            <!-- Account Title — from actual journal entry lines -->
             <table style="width:100%; border:1px solid black; border-collapse:collapse; font-size:12px; margin-bottom:15px;">
               <thead style="background:#f0f0f0;">
                 <tr>
@@ -172,22 +244,39 @@
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td style="border:1px solid black; padding:5px;">Cash (Check Collection)</td>
-                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
-                  <td style="border:1px solid black; padding:5px; text-align:right;"></td>
-                </tr>
-                <tr>
-                  <td style="border:1px solid black; padding:5px;">Accounts Receivable</td>
-                  <td style="border:1px solid black; padding:5px; text-align:right;"></td>
-                  <td style="border:1px solid black; padding:5px; text-align:right;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
-                </tr>
+                <t t-foreach="doc.invoice_line_ids" t-as="line">
+                  <t t-if="not line.display_type">
+                    <tr>
+                      <td style="border:1px solid black; padding:5px;">
+                        <span t-field="line.account_id.name"/>
+                      </td>
+                      <td style="border:1px solid black; padding:5px; text-align:right;">
+                        <t t-if="line.debit">
+                          <span t-esc="line.debit"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </t>
+                      </td>
+                      <td style="border:1px solid black; padding:5px; text-align:right;">
+                        <t t-if="line.credit">
+                          <span t-esc="line.credit"
+                                t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                        </t>
+                      </td>
+                    </tr>
+                  </t>
+                </t>
               </tbody>
               <tfoot>
                 <tr>
                   <td style="border:1px solid black; padding:5px; font-weight:bold;">Total</td>
-                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
-                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;"><span t-field="doc.amount" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/></td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                    <span t-esc="sum(l.debit for l in doc.line_ids if not l.display_type)"
+                          t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                  </td>
+                  <td style="border:1px solid black; padding:5px; text-align:right; font-weight:bold;">
+                    <span t-esc="sum(l.credit for l in doc.line_ids if not l.display_type)"
+                          t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
+                  </td>
                 </tr>
               </tfoot>
             </table>
@@ -204,28 +293,21 @@
               </tr>
             </table>
 
-            <!-- Footer -->
-            <!-- <p style="font-size:10px; margin-top:20px; text-align:center;">
-              THIS DOCUMENT IS NOT VALID FOR CLAIM OF INPUT TAX<br/>
-              Printed By: InnovaThink Corporation.. (Open Edition - Tax Based Accounting System)<br/>
-              Acknowledgment Certificate No.: <br/>
-              Acknowledgment Certificate Date Issued: <br/>
-              Permitted Series Range: OR-000000000001 - OR-999999999999 
-            </p>-->
           </main>
         </div>
       </t>
     </t>
   </template>
 
-  <!-- REPORT ACTION for account.payment -->
+  <!-- Report action bound to account.move (out_invoice) -->
   <record id="action_report_custom_acknowledgement_receipt" model="ir.actions.report">
     <field name="name">Acknowledgment Receipt</field>
-    <field name="model">account.payment</field>
+    <field name="model">account.move</field>
     <field name="report_type">qweb-pdf</field>
     <field name="report_name">itc_internal_dev.report_custom_acknowledgement_receipt_template</field>
-    <field name="print_report_name">'Acknowledgment Receipt Receipt - %s' % (object.name)</field>
-    <field name="binding_model_id" ref="account.model_account_payment"/>
+    <field name="print_report_name">'Acknowledgment Receipt - %s' % (object.name)</field>
+    <field name="binding_model_id" ref="account.model_account_move"/>
     <field name="binding_type">report</field>
   </record>
+
 </odoo>

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -37,3 +37,4 @@ access_disbursement_extra_credit_user,disbursement.extra.credit user,itc_interna
 access_disbursement_expense_type_user,disbursement.expense.type user,itc_internal_dev.model_disbursement_expense_type,base.group_user,1,1,1,1
 access_request_for_payment_user,request.for.payment user,itc_internal_dev.model_request_for_payment,base.group_user,1,1,1,1
 access_request_for_payment_line_user,request.for.payment.line user,itc_internal_dev.model_request_for_payment_line,base.group_user,1,1,1,1
+access_payment_register_tax_line_user,account.payment.register.tax.line user,model_account_payment_register_tax_line,base.group_user,1,1,1,1

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -23,6 +23,12 @@
                             type="action"
                             class="oe_highlight"
                             invisible="True"/>
+                            
+                    <button name="%(action_report_custom_acknowledgement_receipt)d"
+                            string="Print Acknowledgement Receipt"
+                            type="action"
+                            class="oe_highlight"
+                            invisible="payment_state != 'paid' or move_type != 'out_invoice'"/>
                     
                 </xpath>
 

--- a/views/account_payment_register_views.xml
+++ b/views/account_payment_register_views.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- ══════════════════════════════════════════════════════════════
+         account.payment.register wizard — tax breakdown inherit
+    ══════════════════════════════════════════════════════════════════ -->
+    <record id="view_account_payment_register_tax_inherit" model="ir.ui.view">
+        <field name="name">account.payment.register.tax.inherit</field>
+        <field name="model">account.payment.register</field>
+        <field name="inherit_id" ref="account.view_account_payment_register_form"/>
+        <field name="arch" type="xml">
+
+            <!--
+                1. Inject tax_id on the SAME ROW as amount/currency.
+                   The amount row in Odoo 18 register wizard is:
+                     <field name="amount" .../>   (currency_id is its monetary widget sibling)
+                   We add tax_id after the amount field — still inside the group,
+                   so it appears on the same row as a second label+field pair.
+            -->
+            <xpath expr="//field[@name='amount']" position="after">
+                <field name="tax_id"
+                       options="{'no_create': True}"
+                       placeholder="None"/>
+            </xpath>
+
+            <!--
+                2. Breakdown panel goes just before </form> — i.e. after the footer,
+                   at the very bottom of the modal body, spanning full width.
+            -->
+            <xpath expr="//footer" position="before">
+                <div invisible="not tax_id" class="o_payment_tax_breakdown border-top pt-3 mt-1 mx-0">
+
+                    <!-- Section label -->
+                    <div class="o_horizontal_separator mb-2">Tax Breakdown</div>
+
+                    <!-- Summary cards -->
+                    <div class="d-flex gap-2 mb-2">
+
+                        <div class="flex-fill border rounded p-2 text-center bg-100">
+                            <div class="text-muted small mb-1">Base Amount</div>
+                            <div class="fw-bold">
+                                <field name="base_amount" nolabel="1"/>
+                            </div>
+                        </div>
+
+                        <div class="flex-fill border rounded p-2 text-center bg-100">
+                            <div class="text-muted small mb-1">Tax Amount</div>
+                            <div class="fw-bold text-danger">
+                                <field name="tax_amount" nolabel="1"/>
+                            </div>
+                        </div>
+
+                        <div class="flex-fill border rounded p-2 text-center"
+                             style="background-color: var(--o-color-primary, #714B67); color: #fff;">
+                            <div class="small mb-1" style="opacity:0.85">Total (incl. Tax)</div>
+                            <div class="fw-bold">
+                                <field name="total_with_tax" nolabel="1"/>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <!-- Per-tax line breakdown -->
+                    <field name="tax_breakdown_ids" nolabel="1" readonly="1">
+                        <list create="false" delete="false">
+                            <field name="name" string="Tax Component"/>
+                            <field name="base" string="Base"/>
+                            <field name="amount" string="Tax Amount"/>
+                            <field name="account_id" string="Tax Account" optional="show"/>
+                            <field name="currency_id" column_invisible="True"/>
+                        </list>
+                    </field>
+
+                    <!-- Journal entry note -->
+                    <div class="alert alert-info mt-2 mb-0 py-2 px-3">
+                        <i class="fa fa-info-circle me-1"/>
+                        <strong>Journal Entry:</strong>
+                        Bank/Cash = <strong>total (incl. tax)</strong> —
+                        Receivable/Payable = <strong>base amount</strong> —
+                        separate tax line posts to the tax account.
+                    </div>
+
+                </div>
+            </xpath>
+
+        </field>
+    </record>
+
+    <!-- ══════════════════════════════════════════════════════════════
+         account.payment form — show tax info on posted payment
+    ══════════════════════════════════════════════════════════════════ -->
+    <record id="view_account_payment_tax_info_inherit" model="ir.ui.view">
+        <field name="name">account.payment.tax.info.inherit</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+ 
+            <!--
+                Append Tax Summary at the very end of the <sheet> block
+                so it appears below all other fields, before the chatter.
+            -->
+            <xpath expr="//sheet" position="inside">
+                <group invisible="not payment_tax_id" string="Tax Summary"
+                       class="mt-3 border-top pt-3">
+                    <field name="payment_tax_id" string="Applied Tax" readonly="1"/>
+                    <field name="payment_base_amount" string="Base (excl. Tax)" readonly="1"/>
+                    <field name="payment_tax_amount" string="Tax Amount" readonly="1"/>
+                </group>
+            </xpath>
+ 
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary by Sourcery

Adjust acknowledgement receipt reporting to be generated from customer invoices instead of payments and surface related tax information on payments and the payment register wizard.

New Features:
- Add tax selection and computed tax breakdown fields to the account payment register wizard, including a breakdown subview and related transient tax line model.
- Expose payment-level tax summary fields on the account payment form and in the posted payment view.

Bug Fixes:
- Correct acknowledgement receipt fields and calculations to use invoice totals, tax, and reconciled payments rather than payment-specific fields.

Enhancements:
- Rework the acknowledgement receipt QWeb report to read from account.move (customer invoices), displaying invoice lines, amounts, taxes, payment mode breakdown, and journal entry details based on reconciled payments.
- Bind the acknowledgement receipt report action to customer invoices and add a button on paid customer invoices to print the receipt.
- Introduce a dedicated view extension for the payment register wizard to display tax selection and breakdown when enabled.