### PR TITLE
fix naming series for disbursement voucher

### DIFF
--- a/data/account_move_sequence.xml
+++ b/data/account_move_sequence.xml
@@ -6,6 +6,7 @@
         <field name="code">account.move.si</field>
         <field name="prefix">SI</field>
         <field name="padding">12</field>
+        <field name="number_increment">1</field>
         <field name="number_next">1</field>
     </record>
 
@@ -13,8 +14,9 @@
     <record id="seq_account_move_dv" model="ir.sequence">
         <field name="name">Disbursement Voucher Sequence</field>
         <field name="code">account.move.dv</field>
-        <field name="prefix">DV</field>
+        <field name="prefix">CV</field>
         <field name="padding">12</field>
+        <field name="number_increment">1</field>
         <field name="number_next">1</field>
     </record>
 

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -1,14 +1,7 @@
-from odoo import models, fields, api, _
-from odoo.exceptions import UserError
-from odoo.modules.module import get_resource_path
-from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import letter
-from reportlab.lib.utils import simpleSplit
-import io
-import base64
+from odoo import models, fields, api
 
 
-class Account(models.Model):
+class AccountMove(models.Model):
     _inherit = "account.move"
 
     x_invoice_type = fields.Selection(
@@ -27,32 +20,16 @@ class Account(models.Model):
     x_reference_number = fields.Char(string="Reference Number", tracking=True)
 
     def _post(self, soft=True):
-        moves = super()._post(soft)
-
-        for move in moves:
-            if move.move_type == 'out_invoice':
-                move.name = self.env['ir.sequence'].next_by_code('account.move.si')
-            elif move.move_type == 'in_invoice':
-                move.name = self.env['ir.sequence'].next_by_code('account.move.dv')
-
-        return moves
-
-
-    def _get_default_sequence_number(self):
-        # Only override for customer/vendor invoices
-        self.ensure_one()   
-        if self.move_type == 'out_invoice':
-            return self.env['ir.sequence'].next_by_code('account.move.si')
-        elif self.move_type == 'in_invoice':
-            return self.env['ir.sequence'].next_by_code('account.move.dv')
-        return super()._get_default_sequence_number()
+        for move in self:
+            if move.move_type == 'out_invoice' and (not move.name or move.name == '/'):
+                move.name = self.env['ir.sequence'].next_by_code('account.move.si') or 'New'
+            elif move.move_type == 'in_invoice' and (not move.name or move.name == '/'):
+                move.name = self.env['ir.sequence'].next_by_code('account.move.dv') or 'New'
+        return super()._post(soft)
 
     @api.model
     def create(self, vals):
-        self.payment_reference = self.name
-        self.x_reference_number = self.name
         move = super().create(vals)
-        
         if move.invoice_origin:
             sale_order = self.env['sale.order'].search(
                 [('name', '=', move.invoice_origin)], limit=1

--- a/report/disbursement_voucher_report.xml
+++ b/report/disbursement_voucher_report.xml
@@ -36,7 +36,7 @@
                 <table style="width:100%; border-collapse:collapse;">
                   <tr>
                     <td style="border:1px solid black; padding:5px;">Voucher No.</td>
-                    <td style="border:1px solid black; padding:5px;"><t t-esc="doc.name"/></td>
+                    <td style="border:1px solid black; padding:5px;"><t t-esc="doc.memo"/></td>
                   </tr>
                   <tr>
                     <td style="border:1px solid black; padding:5px;">Voucher Date</td>


### PR DESCRIPTION
## Summary by Sourcery

Adjust account move model and sequences to correctly generate and display naming series for sales invoices and disbursement vouchers.

Bug Fixes:
- Ensure sales and vendor invoice names are only generated when missing or placeholder and defer posting to superclass.
- Correct disbursement voucher sequence prefix and explicitly set sequence increments for sales and disbursement vouchers.
- Display the memo field instead of the internal move name as the voucher number on the disbursement voucher report.

Enhancements:
- Rename the custom inherited model class to align with the standard account.move model and remove unused imports and unused default sequence override.