### PR TITLE
2307

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -38,6 +38,7 @@
         'report/cash_advance_report_template.xml',
         'report/disbursement_voucher_report.xml',
         'report/bir_1702q_report.xml',
+        'report/bir_2307_report.xml',
         #Views
         #'views/salary_advance_views.xml',
         'views/expense_sheet.xml',

--- a/data/a4_paperformat.xml
+++ b/data/a4_paperformat.xml
@@ -15,4 +15,25 @@
         <field name="header_spacing">0</field>
         <field name="dpi">90</field>
     </record>
+
+    <record id="paperformat_bir_2307" model="report.paperformat">
+        <field name="name">BIR 2307 Folio Paper</field>
+        <field name="default" eval="False"/>
+        <!-- Remove "A4" and define custom dimensions for Folio (8.5x13 inches) -->
+        <!-- Width: 216 mm, Height: 330 mm -->
+        <field name="format">custom</field>
+        <field name="page_width">216</field>
+        <field name="page_height">330</field>
+        <field name="orientation">Portrait</field>
+
+        <!-- Margins are kept at 5mm as requested -->
+        <field name="margin_top">5</field>
+        <field name="margin_bottom">5</field>
+        <field name="margin_left">5</field>
+        <field name="margin_right">5</field>
+
+        <field name="header_line" eval="False"/>
+        <field name="header_spacing">0</field>
+        <field name="dpi">90</field>
+    </record>
 </odoo>

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api
 
+from odoo.exceptions import ValidationError, UserError
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -38,3 +39,67 @@ class AccountMove(models.Model):
                 move.x_reference_number = sale_order.name
                 move.x_invoice_type = sale_order.x_invoice_type or 'service'
         return move
+
+    def get_2307_details(self):
+        self.ensure_one()
+
+        # only vendor bills
+        if self.move_type != 'in_invoice':
+            return []
+
+        corp_dict = {}
+
+        corp = self.company_id
+
+        corp_dict[corp] = {
+            'corporation': corp,
+            'lines': [],
+            'gross_amount': 0.0,
+            'tax_withheld': 0.0,
+            'net_amount': 0.0,
+        }
+
+        for line in self.invoice_line_ids:
+
+            gross = line.price_subtotal or 0.0
+
+            # ✅ correct tax extraction
+            tax_amount = sum(t.amount for t in line.tax_ids)
+
+            net = gross - tax_amount
+
+            corp_entry = {
+                'description': line.name or '',
+                'atc': ', '.join(line.tax_ids.mapped('name')),
+                'rate': sum(line.tax_ids.mapped('amount')),
+                'month': self.invoice_date.month if self.invoice_date else False,
+                'gross_amount': gross,
+                'tax_withheld': abs(tax_amount),
+                'net_amount': net,
+                'tax_type': '',
+                'payment_term': self.invoice_payment_term_id.name or '',
+                'currency': self.currency_id.name,
+                'conversion_rate': 1.0,
+            }
+
+            corp_dict[corp]['lines'].append(corp_entry)
+
+            corp_dict[corp]['gross_amount'] += gross
+            corp_dict[corp]['tax_withheld'] += abs(tax_amount)
+            corp_dict[corp]['net_amount'] += net
+
+        return list(corp_dict.values())
+
+    def get_2307_business_details(self):
+        """
+        SAME mapping (you had 2 sections)
+        """
+        return self.get_2307_details()
+
+    def action_print(self):
+        self.ensure_one()
+
+        if self.state != 'posted':
+            raise UserError("Payment must be POSTED before generating BIR 2307.")
+
+        return self.env.ref('itc_internal_dev.action_report_bir_2307').report_action(self)

--- a/models/account_payment.py
+++ b/models/account_payment.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError, UserError
 
 class AccountPayment(models.Model):
     _inherit = "account.payment"
@@ -29,6 +30,72 @@ class AccountPayment(models.Model):
         copy=False,
     )
  
+    
+    def get_2307_details(self):
+        self.ensure_one()
+
+        move = self.move_id
+        if not move:
+            return []
+
+        corp_dict = {}
+
+        # ✅ NO FILTER HERE
+        for line in move.line_ids:
+
+            corp = self.company_id
+
+            if corp not in corp_dict:
+                corp_dict[corp] = {
+                    'corporation': corp,
+                    'lines': [],
+                    'gross_amount': 0.0,
+                    'tax_withheld': 0.0,
+                    'net_amount': 0.0,
+                }
+
+            gross = abs(line.debit or line.credit)
+
+            # basic safe tax handling
+            tax_amount = abs(line.balance) if line.tax_line_id else 0.0
+
+            net = gross - tax_amount
+
+            corp_entry = {
+                'description': line.name or '',
+                'atc': line.tax_line_id.name if line.tax_line_id else '',
+                'rate': line.tax_line_id.amount if line.tax_line_id else 0.0,
+                'month': move.date.month if move.date else False,
+                'gross_amount': gross,
+                'tax_withheld': tax_amount,
+                'net_amount': net,
+                'tax_type': '',
+                'payment_term': self.payment_type or '',
+                'currency': move.currency_id.name,
+                'conversion_rate': 1.0,
+            }
+
+            corp_dict[corp]['lines'].append(corp_entry)
+
+            corp_dict[corp]['gross_amount'] += gross
+            corp_dict[corp]['tax_withheld'] += tax_amount
+            corp_dict[corp]['net_amount'] += net
+
+        return list(corp_dict.values())
+    def get_2307_business_details(self):
+        """
+        SAME mapping (you had 2 sections)
+        """
+        return self.get_2307_details()
+
+    def action_print(self):
+        self.ensure_one()
+
+        if self.state != 'paid':
+            raise UserError("Payment must be POSTED before generating BIR 2307.")
+
+        return self.env.ref('itc_internal_dev.action_report_bir_2307').report_action(self)
+
     # ------------------------------------------------------------------
     # Override: inject tax lines into the journal entry move lines
     # ------------------------------------------------------------------

--- a/report/bir_2307_report.xml
+++ b/report/bir_2307_report.xml
@@ -1,0 +1,745 @@
+<odoo>
+
+    <!-- ============================= -->
+    <!-- QWEB TEMPLATE -->
+    <!-- ============================= -->
+   <template id="report_bir_2307">
+        <t t-call="web.html_container">
+            <t t-foreach="docs" t-as="o">
+                <t t-foreach="o.get_2307_details()" t-as="line">
+            <main style="">
+            <div  class="page"
+                    style="font-family: Arial, sans-serif;
+                            font-size: 8pt;
+                            padding: 3px;
+                            page-break-after: always;">
+
+                            <table style="width:100%; margin:0; border-collapse:collapse;">
+                                <!-- Row 1: For BIR Use Only -->
+                                <tr>
+                                    <td style="padding:3px 8px; font-size:8pt; width:15%; vertical-align:top;">
+                                        <span style="font-weight:bold;">For BIR</span> BCS/ <br/>
+                                        <span style="font-weight:bold;">Use Only</span> Item:
+                                    </td>
+
+                                    <td colspan="2" style="padding:3px 8px; font-size:8pt; ">
+                                        <!-- HEADER CONTENT -->
+                                        <table style="margin:0 auto; border-collapse:collapse;">
+                                            <tr>
+                                                <!-- Logo -->
+                                                <td style="width:55px; vertical-align:middle; text-align:right; padding-right:10px;">
+                                                    <img src="https://logodix.com/logo/1578333.png"
+                                                        style="width:50px; height:50px; object-fit:contain;"/>
+                                                </td>
+
+                                                <!-- Agency Info -->
+                                                <td style="vertical-align:middle; text-align:left; line-height:1.2;">
+                                                    <div style="font-size:8pt;">Republic of the Philippines</div>
+                                                    <div style="font-size:8pt; font-weight:bold;">Department of Finance</div>
+                                                    <div style="font-size:8pt; font-weight:bold;">Bureau of Internal Revenue</div>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+
+
+                    <!-- HEADER -->
+                    <table style="width:100%; border-collapse:collapse; border:2px solid black; margin:0;">
+
+                        <tr>
+                            <!-- LEFT: FORM NUMBER -->
+                            <td style="border-right:2px solid black; padding:4px; vertical-align:middle; width:15%;">
+                                <div style="text-align:center;">
+                                    <div>
+                                        <span style="font-size:7pt;">BIR Form No.</span> <br />
+                                        <span style="font-size:34pt; font-weight:bold;">2307</span> <br />
+                                        <span style="font-size:7pt;">January 2018 (ENCS)</span>
+                                    </div>
+                                </div>
+                            </td>
+
+                            <!-- CENTER: TITLE -->
+                            <td style="padding:2px; vertical-align:middle; text-align:center;">
+                                <div style="font-size:17pt; font-weight:bold; line-height:1.15; padding:0 20px;">
+                                    Certificate of Creditable Tax<br/>
+                                    Withheld at Source
+                                </div>
+                            </td>
+
+                            <!-- RIGHT: BARCODE -->
+                            <td style="border-left:1px solid black; padding:4px; vertical-align:middle; text-align:center; width:20%;">
+                                <div style="
+                                    width:100%;
+                                    height:70px;
+                                    
+                                    background:white;
+                                    display:flex;
+                                    align-items:center;
+                                    justify-content:center;
+                                    margin-bottom:2px;
+                                ">
+                                    <img src="https://res.cloudinary.com/dfa1bz6nk/image/upload/v1767769591/odoo/01a_barcode_ylqhbb.png"
+                                        style=" width:100%; height:70px;"/>
+                                </div>
+                                <div style="font-size:7pt;">2307 01/18ENCS</div>
+                            </td>
+                        </tr>
+
+                    </table>
+
+                    <!-- /HEADER -->
+
+                    <!-- FOR THE PERIOD SECTION -->
+                    <table style="width: 100%; border-collapse: collapse; border: 2px solid black; margin: 0;">
+                        <tr> <td colspan="2" style="border-bottom:1px solid black;"> Fill in all applicable spaces. Mark all appropriate boxes with an "X".</td></tr>
+                        <tr>
+                            <td style="background-color: #DCDCDC; width: 50%; padding: 5px;  border-top: 0; border-left: 0; border-bottom: 0;">
+                                <div style="background-color: #DCDCDC; white-space: nowrap; font-size: 8pt;">
+
+                                    <span style="margin-right:15px; vertical-align: middle; font-size:9pt;">
+                                        <b>1</b> For the Period
+                                    </span>
+
+                                    <span style="margin-right:5px; vertical-align: middle;">
+                                        From
+                                    </span>
+
+                                    <!-- Date values -->
+                                    <t t-set="from_mm" t-value="o.date.strftime('%m')"/>
+                                    <t t-set="from_dd" t-value="o.date.strftime('%d')"/>
+                                    <t t-set="from_yy" t-value="o.date.strftime('%y')"/>
+
+                                    <!-- MM -->
+                                    <span t-foreach="from_mm" t-as="d"
+                                        style="display:inline-block;
+                                        background-color: white;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                        ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+                                    <!-- DD -->
+                                    <span t-foreach="from_dd" t-as="d"
+                                        style="display:inline-block;
+                                        background-color: white;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                            ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+                                    <!-- YY -->
+                                    <span t-foreach="from_yy" t-as="d"
+                                        style="display:inline-block;
+                                        background-color: white;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                            ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+                                    <span style="font-size:9pt; margin-left:5px; vertical-align: middle; font-style: italic;">
+                                        (MM/DD/YY)
+                                    </span>
+
+                                </div>
+
+                            </td>
+                            <td style="background-color: #DCDCDC;width: 50%; padding: 5px; border: 0; text-align: right; ">
+                                <div style="background-color: #DCDCDC; white-space: nowrap; font-size: 8pt; margin-right:20px;">
+
+                                    <span style="margin-right:5px; vertical-align: middle;">
+                                        To
+                                    </span>
+
+                                    <!-- Date values -->
+                                    <t t-set="to_mm" t-value="o.date.strftime('%m')"/>
+                                    <t t-set="to_dd" t-value="o.date.strftime('%d')"/>
+                                    <t t-set="to_yy" t-value="o.date.strftime('%y')"/>
+
+                                    <!-- MM -->
+                                    <span t-foreach="to_mm" t-as="d"
+                                        style="background-color: white;
+                                            display:inline-block;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                            ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+
+                                    <!-- DD -->
+                                    <span t-foreach="to_dd" t-as="d"
+                                        style="display:inline-block;
+                                        background-color: white;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                            ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+                                    <!-- YY -->
+                                    <span t-foreach="to_yy" t-as="d"
+                                        style="display:inline-block;
+                                        background-color: white;
+                                            width:15px;
+                                            height:25px;
+                                            line-height:25px;
+                                            border:1px solid black;
+                                            text-align:center;
+                                            vertical-align: middle;
+                                        ">
+                                        <t t-esc="d"/>
+                                    </span>
+
+                                    <span style="font-size:9pt; margin-left:5px; vertical-align: middle; font-style: italic;">
+                                        (MM/DD/YY)
+                                    </span>
+
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <!-- /FOR THE PERIOD SECTION -->
+
+                    <!-- PART I: PAYEE INFORMATION -->
+                    <table style="width: 100%; border-collapse: collapse; border: 2px solid black; border-top: 0; margin: 0; font-size: 9pt;">
+                        <!-- Part I Header -->
+                        <tr>
+                            <td colspan="2" style="text-align:center; background-color: #DCDCDC;  border-bottom: 1px solid black; font-weight: bold; border-left: 0; border-right: 0;">
+                                Part I - Income Recipient/Payee Information
+
+                            </td>
+                        </tr>
+
+                        <!-- Row 2: TIN -->
+                        <tr>
+                            <td style="background-color: #DCDCDC; width: 300px;  border-bottom: 1px solid black; border-left: 0;">
+                                <span style="font-weight: bold; margin-left: 7px;">2</span> Taxpayer Identification Number <i>(TIN)</i>
+                            </td>
+                            <td style="background-color:#DCDCDC; padding:5px; border-bottom:1px solid black; border-right:0;">
+                                <div style="display:flex; align-items:center;">
+
+                                    <!-- Get VAT -->
+                                    <t t-set="vendor_vat" t-value="o.partner_id.vat"/>
+
+                                    <!-- IF VAT EXISTS -->
+                                    <t t-if="vendor_vat">
+                                        <span t-foreach="vendor_vat" t-as="d"
+                                            style="
+                                                display:inline-block;
+                                                background-color:white;
+                                                width:20px;
+                                                height:25px;
+                                                line-height:25px;
+                                                border:1px solid black;
+                                                text-align:center;
+                                                vertical-align:middle;
+                                                font-size:9pt;
+                                                font-family:Arial, sans-serif;
+                                            ">
+                                            <t t-esc="d"/>
+                                        </span>
+                                    </t>
+
+                                    <!-- IF VAT IS EMPTY -->
+                                    <t t-else="">
+                                        <!-- Example: show empty boxes (adjust count as needed) -->
+                                        <span t-foreach="range(15)" t-as="i"
+                                            style="
+                                                display:inline-block;
+                                                background-color:white;
+                                                width:20px;
+                                                height:25px;
+                                                line-height:25px;
+                                                border:1px solid black;
+                                                text-align:center;
+                                                vertical-align:middle;
+                                                font-size:9pt;
+                                                font-family:Arial, sans-serif;
+                                            ">
+                                            
+                                        </span>
+                                    </t>
+
+                                </div>
+                            </td>
+
+                        </tr>
+
+                        <!-- Row 3: Payee's Name -->
+                        <tr>
+                            <td colspan="2" style="background-color: #DCDCDC; padding: 5px 10px; width: 400px;  border-bottom: 1px solid black; border-left: 0;">
+                                <span style="font-weight: bold;">3</span> Payee's Name <i> (Last Name, First Name, Middle Name for Individuals) (Registered Name for Non-Individuals)</i>
+                                <t t-set="payee" t-value="o.partner_id.name"/>
+                                <div style="margin-left: 10px; background-color: white; border: 1px solid black; width:830px; vertical-align:middle; height:25px; line-height:25px; font-size:9pt;">
+                                    <t t-esc="payee"/>
+                                </div>
+                            </td>
+                        </tr>
+                        
+
+                        <!-- Row 4: Registered Address -->
+                        <tr>
+                            <td colspan="2" style="background-color:#DCDCDC; padding:5px 10px; border-bottom:1px solid black; border-left:0;">
+
+                                <table style="width:100%; border-collapse:collapse;">
+                                    <tr>
+                                        <!-- REGISTERED ADDRESS -->
+                                        <td style="width:88%; padding-right:10px; vertical-align:middle;">
+                                            <span style="font-weight:bold; margin-right:5px; font-size:9pt;">4</span> Registered Address
+                                            <div style="margin-left: 10px; background-color:white; border:1px solid black; vertical-align:middle; height:25px; line-height:25px; margin-top:3px; font-size:9pt;">
+                                               <t t-esc="
+                                                    ', '.join(filter(None, [
+                                                        o.partner_id.street,
+                                                        o.partner_id.street2,
+                                                        o.partner_id.city,
+                                                    ]))
+                                                "/>
+                                            </div>
+                                        </td>
+
+                                        <!-- ZIP CODE -->
+                                        <td style="width:20%; vertical-align:middle;">
+                                            <span style="font-weight:bold; margin-right:5px; font-size:9pt;">4A</span> Zip Code
+                                            <div style="display:flex; margin-top:3px; gap:1px;">
+                                                <t t-set="zip_code" t-value="(o.partner_id.zip or '').ljust(4)"/>
+                                                <span t-foreach="zip_code" t-as="d"
+                                                    style="background-color:white; display:inline-block; width:20px; height:25px; line-height:25px; border:1px solid black; text-align:center; font-size:9pt; ">
+                                                    <t t-esc="d"/>
+                                                </span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+
+                            </td>
+                        </tr>
+
+                        <!-- Row 5: Foreign Address -->
+                        <tr>
+                            <td colspan="2" style="background-color: #DCDCDC; padding: 5px 10px; width: 400px;  border-bottom: 1px solid black; border-left: 0;">
+                                <span style="font-weight: bold;">5</span> Foreign Address, <i>if applicable</i>
+
+                                <div style="margin-left: 10px; background-color: white; border: 1px solid black; vertical-align:middle; height:25px; line-height:25px;width:830px;">
+                                
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <!-- /PART I -->
+
+                    <!-- PART II: PAYOR INFORMATION -->
+                    <table style="width: 100%; border-collapse: collapse; border: 2px solid black; border-top: 0; margin: 0; font-size: 9pt;">
+                        <!-- Part I Header -->
+                        <tr>
+                            <td colspan="2" style="text-align:center; background-color: #DCDCDC;  border-bottom: 1px solid black; font-weight: bold; border-left: 0; border-right: 0;">
+                                Part II - Withholding Agent/Payor Information
+                            </td>
+                        </tr>
+
+                        <!-- Row 2: TIN -->
+                        <tr>
+                            <td style="background-color: #DCDCDC; width: 300px;  border-bottom: 1px solid black; border-left: 0;">
+                                <span style="font-weight: bold; margin-left: 7px; font-size: 9pt;">6</span> Taxpayer Identification Number <i>(TIN)</i>
+                            </td>
+                            <td style=" background-color: #DCDCDC;padding: 5px; border-bottom: 1px solid black; border-right: 0;">
+                                 <div style="display: flex; align-items: center;">
+                                    <t t-set="corporation_vat" t-value="line['corporation'].vat"/>
+                                    <!-- TIN boxes with darker separators -->
+                                    <t t-if="corporation_vat">
+                                        <span t-foreach="corporation_vat" t-as="d"
+                                            style="
+                                                display:inline-block;
+                                                background-color:white;
+                                                width:20px;
+                                                height:25px;
+                                                line-height:25px;
+                                                border:1px solid black;
+                                                text-align:center;
+                                                vertical-align:middle;
+                                                font-size:9pt;
+                                                font-family:Arial, sans-serif;
+                                            ">
+                                            <t t-esc="d"/>
+                                        </span>
+                                    </t>
+
+                                    <!-- IF VAT IS EMPTY -->
+                                    <t t-else="">
+                                        <!-- Example: show empty boxes (adjust count as needed) -->
+                                        <span t-foreach="range(15)" t-as="i"
+                                            style="
+                                                display:inline-block;
+                                                background-color:white;
+                                                width:20px;
+                                                height:25px;
+                                                line-height:25px;
+                                                border:1px solid black;
+                                                text-align:center;
+                                                vertical-align:middle;
+                                                font-size:9pt;
+                                                font-family:Arial, sans-serif;
+                                            ">
+                                            
+                                        </span>
+                                    </t>
+                                    
+                                </div>
+                            </td>
+                        </tr>
+
+                        <!-- Row 3: Payee's Name -->
+                        <tr>
+                            <td colspan="2" style="background-color: #DCDCDC; padding: 5px 10px; width: 400px;  border-bottom: 1px solid black; border-left: 0;">
+                                <span style="font-weight: bold;">7</span> Payor's Name <i> (Last Name, First Name, Middle Name for Individuals) (Registered Name for Non-Individuals)</i>
+
+                                <div style="margin-left: 10px; background-color: white; border: 1px solid black; width:830px; vertical-align:middle; height:25px; line-height:25px; font-size:9pt;">
+                                    <t t-esc="line['corporation'].name"/>
+                                </div>
+                            </td>
+                        </tr>
+                        
+
+                        <!-- Row 4: Registered Address -->
+                        <tr>
+                            <td colspan="2" style="background-color:#DCDCDC; padding:5px 10px; border-bottom:1px solid black; border-left:0;">
+
+                                <table style="width:100%; border-collapse:collapse;">
+                                    <tr>
+                                        <!-- REGISTERED ADDRESS -->
+                                        <td style="width:88%; padding-right:10px; vertical-align:middle; font-size:9pt;">
+                                            <span style="font-weight:bold; font-size:9pt;">8</span> Registered Address
+                                            <div style="margin-left:10px; background-color:white; border:1px solid black; vertical-align:middle; height:25px; line-height:25px; font-size:9pt; margin-top:3px;">
+                                                <t t-esc="
+                                                    ', '.join(filter(None, [
+                                                        line['corporation'].street,
+                                                        line['corporation'].street2,
+                                                        line['corporation'].city,
+                                                    ]))
+                                                "/>
+                                            </div>
+                                        </td>
+
+
+                                        <!-- ZIP CODE -->
+                                        <td style="width:20%; vertical-align:middle; font-size:9pt;">
+                                            <span style="font-weight:bold; margin-right:5px; font-size:9pt;">8A</span> Zip Code
+                                            <div style="display:flex; margin-top:3px; gap:1px;">
+                                                <t t-set="zip_code" t-value="(o.company_id.zip or '').ljust(4)"/>
+                                                <span t-foreach="zip_code" t-as="d"
+                                                    style="background-color:white; display:inline-block; width:20px; height:25px; line-height:25px; border:1px solid black; text-align:center; font-size:9pt; ">
+                                                    <t t-esc="d"/>
+                                                </span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+
+                            </td>
+                        </tr>
+                    </table>
+                    <!-- /PART II -->
+
+                    <!-- PART: MONTHLY INCOME AND TAX -->
+                    <table style="width: 100%; border-collapse: collapse; border: 2px solid black; border-top: 0; margin: 0; font-size: 9pt;">
+                        <!-- Part Header -->
+                        <tr>
+                            <td colspan="7" style="background-color: #DCDCDC; padding: 3px 5px; border-bottom: 1px solid black; font-weight: bold; text-align: center; border-left: 0; border-right: 0;">
+                                Part III - details of Monthly Income Payments and Tax Withheld for the Quarter
+                            </td>
+                        </tr>
+
+                        <!-- Column Headers Row 1 -->
+                        <tr style="text-align: center; font-weight: bold; font-size: 7pt;">
+                            <td rowspan="2" style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; border-left: 0; width: 160px; vertical-align: middle;">
+                                Income Payments Subject to<br/>Expanded Withholding Tax
+                            </td>
+                            <td rowspan="2" style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; width: 45px; vertical-align: middle;">
+                                ATC
+                            </td>
+                            <td colspan="3" style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                AMOUNT OF INCOME PAYMENTS
+                            </td>
+                            <td rowspan="2" style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; width: 70px; vertical-align: middle;">
+                                Total
+                            </td>
+                            <td rowspan="2" style="background-color: #DCDCDC; padding: 5px; border-right: 0; border-bottom: 1px solid black; width: 70px; vertical-align: middle;">
+                                Tax Withheld<br/>For the Quarter
+                            </td>
+                        </tr>
+
+                        <!-- Column Headers Row 2 -->
+                        <tr style="text-align: center; font-weight: bold; font-size: 7pt;">
+                            <td style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; width: 85px;">
+                                1st Month of<br/>the Quarter
+                            </td>
+                            <td style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; width: 85px;">
+                                2nd Month of<br/>the Quarter
+                            </td>
+                            <td style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; width: 85px;">
+                                3rd Month of<br/>the Quarter
+                            </td>
+                        </tr>
+
+                        <t t-foreach="o.get_2307_details()" t-as="corp">
+                        <t t-set="lines" t-value="corp['lines']"/>
+                        
+                        <t t-if="line['corporation'] == corp['corporation']">
+                    
+                        <!-- Loop through each line for this corporation -->
+                        <tr t-foreach="lines" t-as="l">
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                <t t-esc="l['description']"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:center;">
+                                <t t-esc="l['atc']"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [1,4,7,10]">
+                                    <!-- <span t-field="o.currency_id.symbol"/> --> <t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [2,5,8,11]">
+                                    <!-- <span t-field="o.currency_id.symbol"/> --> <t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [3,6,9,12]">
+                                    <!-- <span t-field="o.currency_id.symbol"/> --> <t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 0; border-bottom: 1px solid black; text-align:right;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['tax_withheld'])"/>
+                            </td>
+                        </tr>
+
+                        <!-- Optional: add total row per corporation -->
+                        <tr style="font-weight: bold; font-size: 7.5pt;">
+                            <td style="background-color: #DCDCDC; padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; border-left: 0;">
+                                Total
+                            </td>
+                            <td style="border: 1px solid black;"></td>
+                            <td colspan="3" style="border: 1px solid black;"></td>
+                            <td style="text-align:right; border: 1px solid black;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(corp['gross_amount'])"/>
+                            </td>
+                            <td style="text-align:right; border: 1px solid black;">
+                                <!-- <span t-field="o.currency_id.symbol"/> --> <t t-esc="'{:,.2f}'.format(corp['tax_withheld'])"/>
+                            </td>
+                        </tr>
+                    </t>
+                    </t>
+
+                        
+
+                        <!-- Second Section Header -->
+                        <tr style="font-weight: bold; font-size: 7pt;">
+                            <td style="background-color: #DCDCDC; padding: 5px; border-right: 1px solid black; border-bottom: 1px solid black; border-left: 0;">
+                                Money Payments Subject to Withholding Tax on Business/Excise Tax (Government &amp; Private)
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;"></td>
+                        </tr>
+
+                        
+                        <t t-foreach="o.get_2307_business_details()" t-as="corpII">
+                        <t t-set="lines" t-value="corpII['lines']"/>
+                        
+                        <t t-if="line['corporation'] == corpII['corporation']">
+                    
+                        <!-- Loop through each line for this corporation -->
+                        <tr t-foreach="lines" t-as="l">
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                <t t-esc="l['description']"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:center;">
+                                <t t-esc="l['atc']"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [1,4,7,10]">
+                                     <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [2,5,8,11]">
+                                     <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                <t t-if="l['month'] in [3,6,9,12]">
+                                     <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                                </t>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; text-align:right;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['gross_amount'])"/>
+                            </td>
+                            <td style="padding: 6px 5px; border-right: 0; border-bottom: 1px solid black; text-align:right;">
+                                <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(l['tax_withheld'])"/>
+                            </td>
+                        </tr>
+
+                        <!-- Optional: add total row per corporation -->
+                        <tr style="font-weight: bold; font-size: 7.5pt;">
+                            <td style="background-color: #DCDCDC; padding: 6px 5px; border-right: 1px solid black; border-bottom: 1px solid black; border-left: 0;">
+                                Total
+                            </td>
+                            <td style="border: 1px solid black;"></td>
+                            <td colspan="3" style="border: 1px solid black;"></td>
+                            <td style="text-align:right; border: 1px solid black;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(corpII['gross_amount'])"/>
+                            </td>
+                            <td style="text-align:right; border: 1px solid black;">
+                                 <!-- <span t-field="o.currency_id.symbol"/> --><t t-esc="'{:,.2f}'.format(corpII['tax_withheld'])"/>
+                            </td>
+                        </tr>
+                    </t>
+                    </t>
+
+
+                    </table>
+                    <!-- /PART -->
+                    <!-- DECLARATION AND SIGNATURE SECTION -->
+                    <table style="width:100%; border-collapse:collapse; border:2px solid black; border-top:0; font-size:9pt;">
+
+                        <!-- Declaration Text -->
+                        <tr>
+                            <td colspan="6"
+                                style="background:#DCDCDC; padding:5px;
+                                    border:1px solid black; border-top:0; text-align:justify;">
+                                We declare, under the penalties of perjury, that this certificate has been made in good faith,
+                                verified by me, and to the best of my knowledge and belief, is true and correct, pursuant to the
+                                provisions of the National Internal Revenue Code, as amended, and the regulations issued under
+                                authority thereof.
+                            </td>
+                        </tr>
+
+                        <!-- Space for Signature -->
+                        <tr>
+                            <td colspan="6" style="height:30px; border:1px solid black;"></td>
+                        </tr>
+
+                        <!-- Signature Label -->
+                        <tr>
+                            <td colspan="6"
+                                style="background:#DCDCDC; padding:5px; border:1px solid black;">
+                                Signature over Printed Name of Payor / Payor's Authorized Representative / Accredited Tax Agent<br/>
+                                <i>(Indicate Title/Designation and TIN)</i>
+                            </td>
+                        </tr>
+
+                        <!-- Accreditation / Dates -->
+                        <tr>
+                            <td style="background:#DCDCDC; padding:5px; border:1px solid black; width:30%;">
+                                Tax Agent Accreditation No. / Attorney's Roll No. (if applicable)
+                            </td>
+                            <td style="padding:5px; border:1px solid black; width:20%;"></td>
+
+                            <td style="background:#DCDCDC; padding:5px; border:1px solid black; width:15%; text-align:center;">
+                                Date of Issuance<br/><i>(MM/DD/YYYY)</i>
+                            </td>
+                            <td style="padding:5px; border:1px solid black; width:15%;"></td>
+
+                            <td style="background:#DCDCDC; padding:5px; border:1px solid black; width:10%; text-align:center;">
+                                Date of Expiration<br/><i>(MM/DD/YYYY)</i>
+                            </td>
+                            <td style="padding:5px; border:1px solid black; width:10%;"></td>
+                        </tr>
+
+                        <!-- Conforme -->
+                        <tr>
+                            <td colspan="6"
+                                style="background:#DCDCDC; padding:5px; font-weight:bold;
+                                    border:1px solid black; text-align:center;">
+                                CONFORME:
+                            </td>
+                        </tr>
+
+                        <tr>
+                            <td colspan="6" style="height:40px; border:1px solid black;">GINA G. ROSALES, CPA, LLB, MA-T/CHIEF ACCOUNTANT/120-163-961-000</td>
+                        </tr>
+
+                        <!-- Conforme Signature -->
+                        <tr>
+                            <td colspan="6"
+                                style="background:#DCDCDC; padding:5px; border:1px solid black;">
+                                Signature over Printed Name of Payee / Payee's Authorized Representative<br/>
+                                <i>(Indicate Title/Designation and TIN)</i>
+                            </td>
+                        </tr>
+
+                        <!-- Accreditation / Dates (Conforme) -->
+                        <tr>
+                            <td style="background:#DCDCDC; padding:3px 5px; border:1px solid black; width:30%;">
+                                Tax Agent Accreditation No. / Attorney's Roll No. (if applicable)
+                            </td>
+                            <td style="padding:3px 5px; border:1px solid black; width:20%;"></td>
+
+                            <td style="background:#DCDCDC; padding:3px 5px; border:1px solid black; width:15%; text-align:center;">
+                                Date of Issuance<br/><i>(MM/DD/YYYY)</i>
+                            </td>
+                            <td style="padding:3px 5px; border:1px solid black; width:15%;"></td>
+
+                            <td style="background:#DCDCDC; padding:5px; border:1px solid black; width:10%; text-align:center;">
+                                Date of Expiration<br/><i>(MM/DD/YYYY)</i>
+                            </td>
+                            <td style="padding:3px 5px; border:1px solid black; width:10%;"></td>
+                        </tr>
+
+                    </table>
+
+
+                <!-- /DECLARATION AND SIGNATURE SECTION -->
+
+                <p>NOTE: The BIR Data Privacy is in the BIR website (www.bir.gov.ph).</p>
+            </div>
+            </main>
+
+            </t>
+        </t>
+        </t>
+    </template>
+    <!-- ============================= -->
+    <!-- REPORT ACTION -->
+    <!-- ============================= -->
+    <record id="action_report_bir_2307" model="ir.actions.report">
+        <field name="name">BIR Form 2307</field>
+        <field name="model">account.move</field>
+        <field name="report_type">qweb-pdf</field>
+        <field name="report_name">itc_internal_dev.report_bir_2307</field>
+        <field name="report_file">itc_internal_dev.report_bir_2307</field>
+        <field name="paperformat_id" ref="paperformat_bir_2307"/>
+        <field name="print_report_name">'BIR_2307_%s' % (object.name)</field>
+    </record>
+</odoo>

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -29,6 +29,12 @@
                             type="action"
                             class="oe_highlight"
                             invisible="payment_state != 'paid' or move_type != 'out_invoice'"/>
+
+                    <button name="action_print"
+                            string="Print BIR 2307"
+                            type="object"
+                            class="oe_highlight"
+                            invisible="move_type == 'out_invoice'"/>
                     
                 </xpath>
 

--- a/views/account_payment_view.xml
+++ b/views/account_payment_view.xml
@@ -15,6 +15,8 @@
                             type="action"
                             class="oe_highlight"
                             invisible="partner_type != 'supplier'"/>
+                            
+                    
                     
                     
             </xpath>


### PR DESCRIPTION
## Summary by Sourcery

Add support for generating BIR 2307 PDF certificates from vendor bills and payments, including data preparation, report templates, and UI entry points.

New Features:
- Provide helper methods on payments and vendor bills to compute structured BIR 2307 withholding details for reporting.
- Introduce a QWeb BIR 2307 report with custom folio paper format and metadata for PDF generation.
- Expose a 'Print BIR 2307' action on account moves for eligible documents.

Enhancements:
- Register the new BIR 2307 report in the module manifest and link it to the custom paper format for correct layout.