### PR TITLE
add collection receipt

### DIFF
--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -18,6 +18,7 @@
                             type="action"
                             class="oe_highlight"
                             invisible="move_type != 'out_invoice'"/>
+
                     <button name="%(report_sales_invoice_account_move)d"
                             string="Print Sales Invoice"
                             type="action"
@@ -30,12 +31,6 @@
                             class="oe_highlight"
                             invisible="payment_state != 'paid' or move_type != 'out_invoice'"/>
 
-                    <button name="%(action_report_custom_official_receipt)d"
-                            string="Print Official Receipt"
-                            type="action"
-                            class="oe_highlight"
-                            invisible="payment_state != 'paid' or move_type != 'out_invoice'"/>
-                            
 
                     <button name="action_print"
                             string="Print BIR 2307"

--- a/views/account_payment_view.xml
+++ b/views/account_payment_view.xml
@@ -5,11 +5,17 @@
         <field name="inherit_id" ref="account.view_account_payment_form"/>
         <field name="arch" type="xml">
             <xpath expr="//header" position="inside">
-                    <button name="%(action_report_custom_acknowledgement_receipt)d"
+                   <!--  <button name="%(action_report_custom_acknowledgement_receipt)d"
                             string="Print Acknowledgement"
                             type="action"
                             class="oe_highlight"
+                            invisible="partner_type != 'customer'"/> -->
+                    <button name="%(action_report_custom_official_receipt)d"
+                            string="Print Collection Receipt"
+                            type="action"
+                            class="oe_highlight"
                             invisible="partner_type != 'customer'"/>
+                            
                     <button name="%(report_disbursement_voucher_custom)d"
                             string="Print Disbursement Voucher"
                             type="action"


### PR DESCRIPTION
## Summary by Sourcery

Add a collection receipt print action to payments and move the official receipt print action from invoices to payments.

New Features:
- Add a 'Print Collection Receipt' action button to the account payment form for customer payments.

Enhancements:
- Remove the 'Print Official Receipt' action button from customer invoices, consolidating receipt printing actions on the payment form.